### PR TITLE
CI: install Wayland dev packages for Linux build (re-land)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,10 @@ jobs:
             libxinerama-dev \
             libxcursor-dev \
             libxi-dev \
-            libglu1-mesa-dev
+            libglu1-mesa-dev \
+            libwayland-dev \
+            wayland-protocols \
+            libxkbcommon-dev
 
       - name: Configure
         run: cmake -B build -DFETCHCONTENT_UPDATES_DISCONNECTED=ON ${{ matrix.cmake_args }}


### PR DESCRIPTION
## Summary
Re-lands the Wayland CI fix that was dropped from PR #7. That PR was merged at commit `9568cf7`, one commit before the Wayland fix (`3528195`) landed on the branch — so `main` currently has no Wayland dev packages and the Linux job fails at link time with `cannot find -lwayland-egl`.

This restores the fix: adds `libwayland-dev` (provides the `libwayland-egl.so` linker symlink), `wayland-protocols`, and `libxkbcommon-dev` to the Linux dependency step.

## Verification
The identical change already passed the full Linux/macOS/Windows matrix on the prior branch before it was orphaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)