### PR TITLE
M2: platform window layer + bgfx surface init

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,20 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(yaml-cpp)
 
+# GLFW — windowing and input. bgfx renders into the native window handle GLFW
+# creates; GLFW itself creates no graphics context (the renderer sets
+# GLFW_NO_API). On Linux this pulls X11 (and optionally Wayland) dev libraries.
+set(GLFW_BUILD_DOCS     OFF CACHE BOOL "" FORCE)
+set(GLFW_BUILD_TESTS    OFF CACHE BOOL "" FORCE)
+set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(GLFW_INSTALL        OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+  glfw
+  GIT_REPOSITORY https://github.com/glfw/glfw.git
+  GIT_TAG        3.4
+)
+FetchContent_MakeAvailable(glfw)
+
 # GoogleTest
 set(gtest_SOURCE_DIR "${CMAKE_SOURCE_DIR}/external/googletest")
 if(EXISTS "${gtest_SOURCE_DIR}/CMakeLists.txt")
@@ -66,6 +80,7 @@ endif()
 # see include/plugin_api.h).
 file(GLOB_RECURSE ENGINE_SOURCES
     src/core/*.cpp
+    src/platform/*.cpp
     src/plugins/*.cpp
     src/renderer/*.cpp
     src/world/*.cpp
@@ -89,6 +104,7 @@ target_link_libraries(voxel-engine
     bgfx                  # renderer internals only; not exposed in the public API
     bx
     bimg
+    glfw                  # windowing/input; native handles wrapped by src/platform
     yaml-cpp::yaml-cpp
 )
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -279,7 +279,17 @@ Plugins are loaded in declaration order from the project config. Hook registrati
 
 ## 9. Renderer and LOD
 
-**Files:** `src/renderer/Renderer.cpp/.h`, `src/renderer/LODManager.cpp/.h`
+**Files:** `src/renderer/Renderer.cpp/.h`, `src/renderer/BgfxRenderer.cpp/.h`, `src/renderer/LODManager.cpp/.h`, `src/platform/Window.cpp/.h`, `src/platform/NativeWindowHandles.h`
+
+### Windowing and Surface
+
+The window is owned by a separate platform layer (`src/platform/Window`, backed by GLFW), not by the renderer. The window creates no graphics context of its own (`GLFW_NO_API`) — bgfx owns the device and renders into the window's native handle.
+
+The seam between the two is `platform::NativeWindowHandles`, a small struct carrying the native window/display pointers (and a Wayland flag). The window layer produces it; the renderer consumes it to populate `bgfx::PlatformData` in `Renderer::initialize`. This keeps the dependency one-directional and library-neutral: **the window layer never includes bgfx, and the renderer never includes GLFW.** Do not collapse these — a renderer that pulls in GLFW, or a window that pulls in bgfx, defeats the separation that lets either backend be swapped.
+
+bgfx is initialized in single-threaded mode (a `bgfx::renderFrame()` call precedes `bgfx::init`), so device and window calls stay on the main thread — required on macOS and simpler everywhere.
+
+**Linux:** X11 is requested explicitly for now (`GLFW_PLATFORM_X11`); native-handle wiring for Wayland is a planned follow-up. On a Wayland session the window runs through XWayland until then.
 
 ### Layer-Aware Rendering
 
@@ -454,9 +464,15 @@ PropagationSystem
     └── depends on: World (read voxel properties), PhysicsSystem (structural events)
     └── stops at: immutable layer boundaries
 
+Window (platform)
+    └── depends on: GLFW
+    └── produces: NativeWindowHandles (consumed by Renderer)
+    └── must NOT depend on: bgfx, Renderer, World, or any engine subsystem
+
 Renderer
-    └── depends on: World (read geometry), LODManager, WorldCoord
-    └── must NOT depend on: PhysicsSystem, DecompositionWorker, IO
+    └── depends on: World (read geometry), LODManager, WorldCoord,
+                    NativeWindowHandles (from Window, at init only)
+    └── must NOT depend on: GLFW, PhysicsSystem, DecompositionWorker, IO
 
 PhysicsSystem
     └── depends on: World (read/write voxel properties), PropagationSystem

--- a/src/platform/NativeWindowHandles.h
+++ b/src/platform/NativeWindowHandles.h
@@ -1,0 +1,25 @@
+#pragma once
+
+// Platform-neutral native window handles.
+//
+// This is the seam between the windowing layer (src/platform/Window, backed by
+// GLFW) and the renderer (src/renderer/BgfxRenderer, backed by bgfx). The window
+// layer produces these handles; the renderer consumes them to populate
+// bgfx::PlatformData. Neither side depends on the other's third-party library.
+
+namespace platform {
+
+struct NativeWindowHandles {
+    // Native window: HWND (Windows), NSWindow* (macOS), X11 Window (Linux/X11),
+    // or wl_surface* (Linux/Wayland).
+    void* window = nullptr;
+
+    // Native display: X11 Display* or wl_display* on Linux; null on Windows/macOS.
+    void* display = nullptr;
+
+    // True when the handles refer to a Wayland surface/display, so the renderer
+    // can set bgfx::PlatformData::type accordingly. Always false off Linux.
+    bool wayland = false;
+};
+
+}  // namespace platform

--- a/src/platform/Window.cpp
+++ b/src/platform/Window.cpp
@@ -1,0 +1,82 @@
+#include "platform/Window.h"
+
+#include <GLFW/glfw3.h>
+
+// Native-access entry points must be requested per platform before including
+// the native header. bgfx renders into the handles these expose.
+#if defined(_WIN32)
+  #define GLFW_EXPOSE_NATIVE_WIN32
+#elif defined(__APPLE__)
+  #define GLFW_EXPOSE_NATIVE_COCOA
+#elif defined(__linux__)
+  #define GLFW_EXPOSE_NATIVE_X11
+#endif
+#include <GLFW/glfw3native.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+
+namespace platform {
+
+namespace {
+void glfwErrorCallback(int code, const char* description) {
+    std::fprintf(stderr, "[Window] GLFW error %d: %s\n", code, description);
+}
+}  // namespace
+
+Window::Window(int width, int height, const std::string& title) {
+    glfwSetErrorCallback(glfwErrorCallback);
+
+#if defined(__linux__) && defined(GLFW_PLATFORM_X11)
+    // Force X11 for now; native-handle wiring for Wayland is a planned
+    // follow-up (see docs/ARCHITECTURE.md §9). On a Wayland session this runs
+    // through XWayland.
+    glfwInitHint(GLFW_PLATFORM, GLFW_PLATFORM_X11);
+#endif
+
+    if (!glfwInit())
+        throw std::runtime_error("[Window] glfwInit failed");
+
+    // bgfx owns the graphics device; GLFW must not create a GL/GLES context.
+    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+
+    window_ = glfwCreateWindow(width, height, title.c_str(), nullptr, nullptr);
+    if (!window_) {
+        glfwTerminate();
+        throw std::runtime_error("[Window] glfwCreateWindow failed");
+    }
+}
+
+Window::~Window() {
+    if (window_) glfwDestroyWindow(window_);
+    glfwTerminate();
+}
+
+NativeWindowHandles Window::nativeHandles() const {
+    NativeWindowHandles handles;
+#if defined(_WIN32)
+    handles.window = static_cast<void*>(glfwGetWin32Window(window_));
+#elif defined(__APPLE__)
+    handles.window = glfwGetCocoaWindow(window_);  // 'id' is void* in non-ObjC builds
+#elif defined(__linux__)
+    handles.window =
+        reinterpret_cast<void*>(static_cast<uintptr_t>(glfwGetX11Window(window_)));
+    handles.display = glfwGetX11Display();
+#endif
+    return handles;
+}
+
+bool Window::shouldClose() const {
+    return glfwWindowShouldClose(window_) != 0;
+}
+
+void Window::pollEvents() {
+    glfwPollEvents();
+}
+
+void Window::framebufferSize(int& width, int& height) const {
+    glfwGetFramebufferSize(window_, &width, &height);
+}
+
+}  // namespace platform

--- a/src/platform/Window.h
+++ b/src/platform/Window.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "platform/NativeWindowHandles.h"
+
+#include <string>
+
+struct GLFWwindow;
+
+namespace platform {
+
+// A GLFW-backed application window.
+//
+// The window creates no graphics context of its own (GLFW_NO_API) — bgfx owns
+// the device and renders into the native handle exposed by nativeHandles().
+// One Window owns GLFW's global state for the process; construct exactly one.
+//
+// Linux note: X11 is requested explicitly for now. Wayland support is a planned
+// follow-up (see docs/ARCHITECTURE.md §9).
+class Window {
+public:
+    // Throws std::runtime_error if GLFW or window creation fails.
+    Window(int width, int height, const std::string& title);
+    ~Window();
+
+    Window(const Window&)            = delete;
+    Window& operator=(const Window&) = delete;
+
+    // Native handles for the renderer to populate bgfx::PlatformData.
+    NativeWindowHandles nativeHandles() const;
+
+    bool shouldClose() const;
+    void pollEvents();
+
+    // Framebuffer size in pixels (may differ from window size on HiDPI displays).
+    void framebufferSize(int& width, int& height) const;
+
+    GLFWwindow* glfwHandle() const { return window_; }
+
+private:
+    GLFWwindow* window_ = nullptr;
+};
+
+}  // namespace platform

--- a/src/renderer/BgfxRenderer.cpp
+++ b/src/renderer/BgfxRenderer.cpp
@@ -45,12 +45,27 @@ BgfxRenderer::~BgfxRenderer() {
     shutdown();
 }
 
-void BgfxRenderer::initialize() {
+void BgfxRenderer::initialize(const platform::NativeWindowHandles& handles,
+                              uint32_t width, uint32_t height) {
+    viewWidth  = width;
+    viewHeight = height;
+
+    // Render on the calling thread (single-threaded mode). Calling renderFrame()
+    // before init avoids bgfx spawning its own render thread — simpler and
+    // required on platforms (notably macOS) where window/device calls must stay
+    // on the main thread.
+    bgfx::renderFrame();
+
     bgfx::Init init;
-    init.type              = bgfx::RendererType::Count;
+    init.type              = bgfx::RendererType::Count;  // auto-select per platform
     init.resolution.width  = viewWidth;
     init.resolution.height = viewHeight;
     init.resolution.reset  = BGFX_RESET_VSYNC;
+
+    init.platformData.nwh = handles.window;
+    init.platformData.ndt = handles.display;
+    if (handles.wayland)
+        init.platformData.type = bgfx::NativeWindowHandleType::Wayland;
 
     if (!bgfx::init(init)) {
         std::cerr << "[BgfxRenderer] Failed to initialize bgfx\n";

--- a/src/renderer/BgfxRenderer.h
+++ b/src/renderer/BgfxRenderer.h
@@ -18,7 +18,8 @@ public:
     BgfxRenderer();
     ~BgfxRenderer() override;
 
-    void initialize() override;
+    void initialize(const platform::NativeWindowHandles& handles,
+                    uint32_t width, uint32_t height) override;
     void render() override;
     void drawVoxel(const WorldCoord& position) override;
     void setViewport(int width, int height) override;

--- a/src/renderer/Renderer.h
+++ b/src/renderer/Renderer.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "WorldCoord.h"
+#include "platform/NativeWindowHandles.h"
+
+#include <cstdint>
 
 // Abstract renderer interface.
 // Camera position uses WorldCoord so the renderer can implement floating-origin
@@ -8,7 +11,11 @@
 class Renderer {
 public:
     virtual ~Renderer() = default;
-    virtual void initialize() = 0;
+
+    // Initialize the graphics device against an existing native window surface.
+    // width/height are the initial framebuffer size in pixels.
+    virtual void initialize(const platform::NativeWindowHandles& handles,
+                            uint32_t width, uint32_t height) = 0;
     virtual void render() = 0;
 
     // Submit a voxel at world-space position for rendering this frame.


### PR DESCRIPTION
## Summary
First logical step of **M2 — Basic Rendering**: stand up windowing and a live bgfx device. This lands the foundation everything else in M2 builds on (shaders, camera transform, render loop). **No frame is drawn yet** — that chain is verified by the single-voxel demo at the *end* of M2.

## Changes
- **GLFW 3.4** via FetchContent, linked `PRIVATE` to `voxel-engine`.
- **New `src/platform/` layer:**
  - `Window` — GLFW-backed, context-less window (`GLFW_NO_API`); polls events, reports framebuffer size, exposes native handles. Win32 / Cocoa / X11 implemented.
  - `NativeWindowHandles` — a library-neutral seam so the **window layer never includes bgfx and the renderer never includes GLFW**.
- **`Renderer::initialize(handles, w, h)`** — `BgfxRenderer` populates `bgfx::PlatformData` and inits in **single-threaded mode** (`renderFrame()` before `init`), keeping device/window calls on the main thread (required on macOS).
- **Linux:** X11 requested explicitly; Wayland native-handle wiring is a documented follow-up (runs through XWayland until then).
- **Docs:** architecture.md §9 gains a "Windowing and Surface" subsection; §13 dependency map gains the `Window` subsystem with its one-directional boundary.

## Verification
- Builds clean on Windows locally; cross-platform compile is what this PR's CI confirms (the native-handle glue is the cross-platform-risky part).
- Runtime (a window actually opening + clearing) is intentionally exercised later by the end-of-M2 demo, not here.

## Not in this PR (remaining M2, in order)
Shader toolchain → per-frame camera (view/projection) → render loop wired into a demo → voxel grid read → palette colors → free-camera movement → single-voxel demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)