### PR TITLE
CI: build each commit once (scope push to main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,14 @@
 name: CI
 
 on:
-  push:
-    branches: ["**"]
+  # Validate every PR (GitHub builds the merge result). This is the run that
+  # gates merging, and it covers all feature-branch work.
   pull_request:
-    branches: ["**"]
+  # Only build direct pushes to main (merges + the occasional direct commit).
+  # Scoping push to main means a branch with an open PR is no longer built
+  # twice (once for the push, once for the PR) — only the PR run fires.
+  push:
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
The workflow triggered on `push` **and** `pull_request` for all branches, so any branch with an open PR built the same commit twice.

Fix: keep `pull_request` (validates every PR, and GitHub builds the *merge result*), and scope `push` to `main` only. Net effect:
- **Feature branches:** build once, via the PR.
- **`main`:** still validated on direct commits and on merges.

## Demonstrates itself
With the new config on this branch, the branch `push` no longer matches the `push` filter, so opening this PR produces a **single** CI run (the `pull_request` one) instead of two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)