### PR TITLE
Add platformer mechanics: voxel editing, persistence, and raycast targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,21 +491,21 @@ Development is organized into two phases. Phase 1 targets a minimum viable engin
 > M7b adds no new engine subsystems — it is the integration milestone that proves the Phase 1 MVP by building a small but complete **3D platformer** inside a 500 m arena, deliberately exercising every M1–M7 capability at once. The arena is a five-layer stack: a single 500 m **immutable** voxel whose top face is the floor, a 20 m **immutable** perimeter wall with landmark towers, 10 m **composite** platforms that decompose on approach into the 1 m **terminal** build layer, and 2 m **immutable** props between. Decomposition stays single-step (a 10 m platform → its 1 m child grid, per M6); the deep lazy 500→20→10→2→1 cascade is intentionally left to M10. The objective is *collect-the-keys-then-reach-the-goal*: the scattered keys and the goal totem are MagicaVoxel `.vox` models imported with their authored colors. All new code lives in one new demo (`07-arena-platformer`) and two new plugins (`arena`, `hazards`) — no engine or `plugin_api.h` change is required.
 
 *Arena world — layer stack, generation, and materials (M1, M3, M4)*
-- [ ] Five-layer `LayerConfig` (`foundation` 500 m immutable / `ramparts` 20 m immutable / `terraces` 10 m composite → `detail` / `props` 2 m immutable / `detail` 1 m terminal); integer ratios 25:1, 2:1, 5:1, 2:1 validated at startup, demonstrating the validator on a real multi-scale stack
-- [ ] New `arena` plugin registers a layer generator per layer (floor slab, perimeter wall + towers, coarse terraces, small props, fine detail) and the arena materials (stone, grass, hazard-lava, goal-gold), all deterministic (no `rand`/`time`/unordered iteration, architecture.md §4)
-- [ ] The 1 m `detail` layer streams within its `view_distance_chunks` budget around the player (a 500 m arena at 1 m is ~125 M voxels — streaming is mandatory, not optional); every layer drives `LODManager` on its own budget
-- [ ] A feature generator stamps key pickups and platform decorations onto the generated platforms (the M4 feature-generator hook, applied after the base layer generator)
+- [x] Five-layer `LayerConfig` (`foundation` 500 m immutable / `ramparts` 20 m immutable / `terraces` 10 m composite → `detail` / `props` 2 m immutable / `detail` 1 m terminal); integer ratios 25:1, 2:1, 5:1, 2:1 validated at startup, demonstrating the validator on a real multi-scale stack
+- [x] New `arena` plugin registers a layer generator per layer (floor slab, perimeter wall + towers, coarse terraces, small props, fine detail) and the arena materials (stone, grass, hazard-lava, goal-gold), all deterministic (no `rand`/`time`/unordered iteration, architecture.md §4)
+- [x] The 1 m `detail` layer streams within its `view_distance_chunks` budget around the player (a 500 m arena at 1 m is ~125 M voxels — streaming is mandatory, not optional); every layer drives `LODManager` on its own budget
+- [x] A feature generator stamps key pickups and platform decorations onto the generated platforms (the M4 feature-generator hook, applied after the base layer generator)
 
 *Multi-scale world — decomposition, modes, and collision (M6)*
-- [ ] Drive single-step decomposition on approach in the demo: `terraces` macro voxels within a radius are enqueued to `DecompositionWorker` and drained on the main thread into the `detail` layer (the proven M6 path); distant terraces render as 10 m blocks via the scaled `renderChunk`
-- [ ] Cross-layer collision via `World::anySolidAt`: the kinematic player stands on the 500 m floor, the 20 m ramparts, the 2 m props, and 1 m platforms simultaneously, each sampled at its own scale
-- [ ] Immutable floor / walls / props render and collide but never decompose, dirty, or persist; only `detail` edits are persistent
+- [x] Drive single-step decomposition on approach in the demo: `terraces` macro voxels within a radius are enqueued to `DecompositionWorker` and drained on the main thread into the `detail` layer (the proven M6 path); distant terraces render as 10 m blocks via the scaled `renderChunk`
+- [x] Cross-layer collision via `World::anySolidAt`: the kinematic player stands on the 500 m floor, the 20 m ramparts, the 2 m props, and 1 m platforms simultaneously, each sampled at its own scale
+- [x] Immutable floor / walls / props render and collide but never decompose, dirty, or persist; only `detail` edits are persistent
 
 *Platformer mechanics (M2, M5)*
-- [ ] Walk mode with gravity, jump, and grounded state (the M5 kinematic body) is the core traversal; swept axis-separated AABB collision lands the player on platforms and stops them at walls
-- [ ] Free-fly camera (F) to survey the course; floating-origin submission keeps sub-meter precision 250 m+ from the arena center (M2)
-- [ ] Build/break on the `detail` layer (raycast + `setVoxel`, 1–9 material select) lets the player bridge gaps or make shortcuts; edited chunks re-mesh and fire `on_voxel_modified`
-- [ ] Player edits persist across runs (chunk-granular dirty tracking + `WorldSave`), so a built bridge is still there on relaunch
+- [x] Walk mode with gravity, jump, and grounded state (the M5 kinematic body) is the core traversal; swept axis-separated AABB collision lands the player on platforms and stops them at walls
+- [x] Free-fly camera (F) to survey the course; floating-origin submission keeps sub-meter precision 250 m+ from the arena center (M2)
+- [x] Build/break on the `detail` layer (raycast + `setVoxel`, 1–9 material select) lets the player bridge gaps or make shortcuts; edited chunks re-mesh and fire `on_voxel_modified`
+- [x] Player edits persist across runs (chunk-granular dirty tracking + `WorldSave`), so a built bridge is still there on relaunch
 
 *Game objective — collect keys, reach the goal (demo logic + M7)*
 - [ ] Keys and the goal totem are imported `.vox` models (`Engine::importVox`) placed at world anchors and rendered with their authored palette colors (the M7 color round-trip)

--- a/demos/07-arena-platformer/main.cpp
+++ b/demos/07-arena-platformer/main.cpp
@@ -1,4 +1,4 @@
-// M7b demo — arena platformer (Groups 1+2: world generation and decomposition).
+// M7b demo — arena platformer (Groups 1-3: world generation, decomposition, and platformer mechanics).
 //
 // A five-layer walled arena exercises the full M1–M6 feature set at once:
 //
@@ -18,8 +18,21 @@
 // A feature generator stamps gold key-marker voxels above each non-goal platform;
 // these are applied to detail chunks after base generation (M4 hook).
 //
+// Platformer mechanics (Group 3):
+//   - Walk mode: kinematic body with gravity, jumping, and swept AABB collision
+//     across all five layers (the M5 kinematic body, wired to World::anySolidAt).
+//   - Free-fly camera (F): floating-origin submission keeps sub-meter precision
+//     across the full 500 m arena (M2).
+//   - Build/break: left mouse breaks a 1 m detail voxel, right mouse places the
+//     selected material (1–9). Edited chunks are re-meshed immediately and fire
+//     on_voxel_modified. The DDA raycast targets only resident detail layer voxels.
+//   - Persistence: dirty detail chunks are saved to "arena-save/" on eviction and
+//     on quit. On relaunch saved chunks are preferred over re-generating from the
+//     detail generator, so player-built bridges survive across sessions.
+//
 // Controls: WASD move, mouse look, Space/Shift fly up/down (or jump in walk mode),
-// G = walk (gravity + cross-layer AABB collision), F = cursor, ESC quits.
+// G = walk (gravity + cross-layer AABB collision), F = cursor, left mouse = break,
+// right mouse = place, 1–9 = material, ESC quits.
 //
 // Run from the build directory:
 //   ./build/07-arena-platformer
@@ -28,6 +41,7 @@
 #include "core/Engine.h"
 #include "core/LayerConfig.h"
 #include "core/PluginManager.h"
+#include "io/ChunkPersistence.h"
 #include "platform/Window.h"
 #include "renderer/BgfxRenderer.h"
 #include "renderer/ChunkMesh.h"
@@ -37,6 +51,7 @@
 #include "world/DecompositionWorker.h"
 #include "world/MacroVoxel.h"
 #include "world/VoxelCollision.h"
+#include "world/VoxelRaycast.h"
 #include "world/World.h"
 
 #include <GLFW/glfw3.h>
@@ -72,6 +87,9 @@ constexpr double kGravity    = 25.0;
 constexpr double kJumpSpeed  =  9.0;
 constexpr double kEyeOffset  =  0.7;
 const glm::dvec3 kPlayerHalf(0.3, 0.9, 0.3);
+
+// ── Build / edit constants ────────────────────────────────────────────────────
+constexpr double kReachM = 8.0;  // how far the player can target a detail voxel
 
 using MeshStore = std::unordered_map<ChunkCoord, ChunkMesh, ChunkCoordHash>;
 
@@ -170,6 +188,17 @@ layers:
         return 1;
     }
 
+    // Build-material palette: every registered material is selectable (keys 1-9).
+    const auto& materials = pluginManager.materials();
+    if (materials.empty()) {
+        std::cerr << "[main] Fatal: no materials registered by the arena plugin.\n";
+        return 1;
+    }
+    size_t selectedMaterial = 0;
+    std::cout << "[main] Build materials (press the number to select):\n";
+    for (size_t i = 0; i < materials.size() && i < 9; ++i)
+        std::cout << "       " << (i + 1) << " - " << materials[i].material_id << "\n";
+
     // ── Engine + window + renderer ────────────────────────────────────────────
     Engine engine;
     engine.start();
@@ -193,6 +222,15 @@ layers:
         std::cerr << "[main] Fatal: expected all five arena layers.\n";
         return 1;
     }
+
+    // ── Persistence: dirty detail chunks survive across launches ─────────────
+    // The "detail" layer is the terminal layer and the only one the player edits.
+    // Dirty chunks are saved on eviction (save-then-evict) and on quit.
+    const LayerDef* detailDef = layerConfig.findLayer("detail");
+    persistence::WorldSave detailSave(
+        "arena-save",
+        persistence::WorldIdentity{detailDef->voxel_size_m, detailDef->chunk_size_voxels});
+    std::cout << "[main] Save directory: " << detailSave.directory() << "\n";
 
     // ── LOD + decomposition ───────────────────────────────────────────────────
     LODManager lod(layerConfig);
@@ -227,6 +265,31 @@ layers:
                      chunk.data(), f.user_data);
     };
 
+    // ── Detail layer edit helpers ─────────────────────────────────────────────
+    // Rebuild the GPU mesh for a detail chunk after an edit.
+    auto remeshDetailChunk = [&](const ChunkCoord& cc) {
+        const Chunk* chunk = detail->getChunk(cc);
+        if (!chunk) return;
+        auto it = detailMeshes.find(cc);
+        if (it != detailMeshes.end()) {
+            it->second.destroy();
+            it->second = ChunkMesh::build(*chunk);
+        } else {
+            detailMeshes.emplace(cc, ChunkMesh::build(*chunk));
+        }
+    };
+
+    // Write a voxel in the detail layer, fire on_voxel_modified, and re-mesh.
+    // No-op if the chunk is not resident (setVoxel returns false).
+    auto editDetailVoxel = [&](const chunkmath::VoxelCoord& vc, const Voxel& newVox) {
+        const WorldCoord center = chunkmath::voxelCenter(vc, detail->voxelSizeM());
+        const Voxel oldVox = world.getVoxel(center);
+        if (!world.setVoxel(center, newVox)) return;
+        for (const auto& h : pluginManager.voxelModifiedHooks())
+            if (h.fn) h.fn(center, &oldVox, &newVox, h.user_data);
+        remeshDetailChunk(chunkmath::voxelToChunkLocal(vc, detail->chunkSizeVoxels()).chunk);
+    };
+
     // ── Camera / player state ─────────────────────────────────────────────────
     float      pitch = -0.25f, yaw = 0.0f;
     // Start inside the arena, near the ground, facing the central platform.
@@ -235,6 +298,7 @@ layers:
     bool       firstMouse = true;
     bool       cursorCaptured = true;
     bool       prevKeyF = false, prevKeyG = false;
+    bool       prevLeft = false, prevRight = false;
 
     bool       walkMode = false;
     WorldCoord playerCenter(0.0, 0.0, 0.0);
@@ -250,8 +314,10 @@ layers:
                  "ramparts (20m) + terraces (10m) + props (2m) + detail (1m).\n"
                  "[main] WASD + mouse to fly, Space/Shift up/down, G = walk "
                  "(cross-layer collision), F = cursor, ESC quits.\n"
-                 "[main] Fly toward the stone platforms to watch them decompose "
-                 "into grass-topped 1 m detail.\n";
+                 "[main] Left mouse = break detail voxel, right mouse = place, "
+                 "1-9 = select material.\n"
+                 "[main] Fly toward platforms to decompose them; build bridges to "
+                 "cross gaps. Edits save to arena-save/ and survive relaunch.\n";
 
     while (!window.shouldClose()) {
         window.pollEvents();
@@ -286,6 +352,16 @@ layers:
                       << "\n";
         }
         prevKeyG = curKeyG;
+
+        // Material selection (1-9): choose what the right mouse places.
+        for (int i = 0; i < 9 && i < static_cast<int>(materials.size()); ++i) {
+            if (glfwGetKey(glfwWin, GLFW_KEY_1 + i) == GLFW_PRESS &&
+                selectedMaterial != static_cast<size_t>(i)) {
+                selectedMaterial = static_cast<size_t>(i);
+                std::cout << "[main] Selected material: "
+                          << materials[selectedMaterial].material_id << "\n";
+            }
+        }
 
         // Mouse look.
         if (cursorCaptured) {
@@ -384,6 +460,12 @@ layers:
                                         it->second.destroy();
                                         detailMeshes.erase(it);
                                     }
+                                    // Save dirty detail child before eviction.
+                                    if (world.isChunkDirty(dc)) {
+                                        if (const Chunk* ch = world.getChunk(dc))
+                                            detailSave.saveChunk(*ch);
+                                        world.clearChunkDirty(dc);
+                                    }
                                     detail->unloadChunk(dc);
                                 }
                                 decomp.clear(V);
@@ -430,14 +512,25 @@ layers:
         }
 
         // ── Integrate completed decomposition results ─────────────────────────
+        // For each generated detail chunk, prefer a player-saved version over the
+        // freshly generated one — so player bridges survive across sessions.
         std::unordered_set<ChunkCoord, ChunkCoordHash> terracesToRemesh;
         for (DecompositionResult& result : worker.drain()) {
             for (auto& chunkPtr : result.chunks) {
                 const ChunkCoord dc = chunkPtr->coord();
+                // Prefer a saved (player-edited) chunk over the generator output.
+                bool fromSave = false;
+                if (detailSave.hasChunk(dc)) {
+                    if (auto saved = detailSave.tryLoadChunk(dc)) {
+                        chunkPtr  = std::move(saved);
+                        fromSave  = true;
+                    }
+                }
                 Chunk* inserted = detail->insertChunk(std::move(chunkPtr));
                 if (!inserted) continue;
-                // Apply feature generators (key-spot markers) after base generation.
-                applyFeatures(*inserted);
+                // Apply feature generators only to freshly generated chunks —
+                // saved chunks already incorporate the player's edits.
+                if (!fromSave) applyFeatures(*inserted);
                 auto it = detailMeshes.find(dc);
                 if (it != detailMeshes.end()) {
                     it->second.destroy();
@@ -463,8 +556,9 @@ layers:
         }
 
         // ── Release detail chunks that have drifted past the keep radius ──────
-        // Revert the parent terrace macro voxel to its solid block so it still
-        // renders and collides (as a coarse block) and re-decomposes on approach.
+        // Save dirty chunks before dropping them, then revert the parent terrace
+        // macro voxel to its solid block so it still renders/collides and
+        // re-decomposes on approach.
         std::vector<ChunkCoord> detailToEvict;
         for (const auto& kv : detailMeshes) {
             // For terraces(10m)/detail(10m chunks), the macro VoxelCoord equals
@@ -475,6 +569,12 @@ layers:
                 detailToEvict.push_back(kv.first);
         }
         for (const ChunkCoord& dc : detailToEvict) {
+            // Save-then-evict: write the chunk to disk before dropping it so player
+            // edits are never lost when the camera moves away.
+            if (world.isChunkDirty(dc)) {
+                if (const Chunk* ch = world.getChunk(dc)) detailSave.saveChunk(*ch);
+                world.clearChunkDirty(dc);
+            }
             auto it = detailMeshes.find(dc);
             if (it != detailMeshes.end()) {
                 it->second.destroy();
@@ -504,6 +604,47 @@ layers:
                 it->second = ChunkMesh::build(*chunk);
             }
         }
+
+        // ── Targeting and edits (detail layer) ───────────────────────────────
+        // The DDA raycast targets resident 1 m detail voxels only (primary layer).
+        // The player can break and place voxels to bridge gaps or make shortcuts.
+        glm::dvec3 lookDir{double(cp * sy), double(sp), double(cp * cy)};
+        voxelcast::RayHit hit = voxelcast::raycast(world, camPos, lookDir, kReachM);
+        if (hit.hit)
+            renderer.drawVoxelHighlight(
+                chunkmath::voxelCenter(hit.voxel, detail->voxelSizeM()),
+                static_cast<float>(detail->voxelSizeM()));
+
+        bool curLeft  = (glfwGetMouseButton(glfwWin, GLFW_MOUSE_BUTTON_LEFT)  == GLFW_PRESS);
+        bool curRight = (glfwGetMouseButton(glfwWin, GLFW_MOUSE_BUTTON_RIGHT) == GLFW_PRESS);
+
+        if (hit.hit && curLeft && !prevLeft) {
+            editDetailVoxel(hit.voxel, Voxel::empty());  // break
+        }
+        if (hit.hit && curRight && !prevRight) {
+            // Guard against placing into the space the player occupies.
+            const double vs = detail->voxelSizeM();
+            const chunkmath::VoxelCoord t = hit.adjacent;
+            bool blockedByPlayer;
+            if (walkMode) {
+                glm::dvec3 cmin{double(t.x) * vs, double(t.y) * vs, double(t.z) * vs};
+                glm::dvec3 cmax = cmin + glm::dvec3(vs, vs, vs);
+                glm::dvec3 pmin = playerCenter.value - kPlayerHalf;
+                glm::dvec3 pmax = playerCenter.value + kPlayerHalf;
+                blockedByPlayer = (pmin.x < cmax.x && pmax.x > cmin.x &&
+                                   pmin.y < cmax.y && pmax.y > cmin.y &&
+                                   pmin.z < cmax.z && pmax.z > cmin.z);
+            } else {
+                blockedByPlayer = (t == chunkmath::worldToVoxel(camPos, vs));
+            }
+            if (!blockedByPlayer) {
+                Voxel placed;
+                placed.material = materials[selectedMaterial].props;
+                editDetailVoxel(t, placed);
+            }
+        }
+        prevLeft  = curLeft;
+        prevRight = curRight;
 
         // ── Resize ────────────────────────────────────────────────────────────
         int w, h;
@@ -540,6 +681,12 @@ layers:
 
     std::cout << "[main] Decomposed terrace macro voxels this session: "
               << decomp.decomposedCount() << "\n";
+
+    // Persist any edited detail chunks still in memory so they survive the next launch.
+    int savedOnQuit = detailSave.saveDirtyChunks(world);
+    if (savedOnQuit > 0)
+        std::cout << "[main] Saved " << savedOnQuit << " edited detail chunk(s) to "
+                  << detailSave.directory() << "\n";
 
     for (auto& kv : foundationMeshes) kv.second.destroy();
     for (auto& kv : rampartsMeshes)   kv.second.destroy();

--- a/tests/ArenaPlatformerMechanicsTest.cpp
+++ b/tests/ArenaPlatformerMechanicsTest.cpp
@@ -1,0 +1,271 @@
+// M7b tests — platformer mechanics (Group 3).
+//
+// Tests: dirty-chunk tracking after voxel edits in the detail layer, and a full
+// persistence round-trip for a player-built platform.  These run headlessly —
+// no window, no plugin, no renderer — so they are pure unit tests of the engine
+// subsystems that the arena platformer wires together.
+//
+// The "detail" layer is the 1 m terminal layer the player edits with left/right
+// mouse. Dirty tracking (setVoxel → isChunkDirty) and persistence (saveChunk /
+// tryLoadChunk / saveDirtyChunks) are the same M5 primitives used by demo 04;
+// these tests verify they compose correctly with the multi-layer arena world.
+
+#include "core/LayerConfig.h"
+#include "io/ChunkPersistence.h"
+#include "world/Chunk.h"
+#include "world/ChunkCoordMath.h"
+#include "world/Voxel.h"
+#include "world/World.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+// Simple generator: fills with stone at Y < 0 (mimics a floor slab), empty otherwise.
+void flatStoneGen(WorldCoord origin, int n, Voxel* out, void* /*ud*/) {
+    MaterialProperties stone{};
+    stone.density             = 2700.0f;
+    stone.structural_strength = 0.8f;
+    stone.hardness            = 0.6f;
+    stone.palette_index       = 1;
+    const Voxel stoneVoxel{stone};
+    for (int z = 0; z < n; ++z)
+        for (int y = 0; y < n; ++y)
+            for (int x = 0; x < n; ++x)
+                out[x + n * (y + n * z)] =
+                    (origin.value.y < 0.0) ? stoneVoxel : Voxel::empty();
+}
+
+// Create the detail-layer LayerDef (1 m terminal, chunk_size=10) matching the
+// arena config used by the 07-arena-platformer demo.
+LayerDef makeDetailDef() {
+    LayerDef d;
+    d.name                 = "detail";
+    d.voxel_size_m         = 1.0;
+    d.chunk_size_voxels    = 10;
+    d.mode                 = VoxelMode::terminal;
+    d.view_distance_chunks = 12;
+    return d;
+}
+
+// A gold marker placed by the player (palette_index=12, low density).
+Voxel goldMarker() {
+    MaterialProperties m{};
+    m.palette_index = 12;
+    m.density       = 100.0f;
+    return Voxel{m};
+}
+
+// Returns a unique temporary directory path (not yet created; WorldSave creates it).
+std::string tempDir(const std::string& suffix) {
+    return (std::filesystem::temp_directory_path() /
+            ("voxelengine_test_arena_" + suffix)).string();
+}
+
+}  // namespace
+
+// ── Group 3: Dirty tracking after voxel edits ────────────────────────────────
+
+TEST(ArenaPlatformerMechanics, EditDetailVoxelMarksDirty) {
+    // A fresh chunk generated from a pure generator is clean; writing a voxel
+    // into it via world.setVoxel marks it dirty.
+    LayerDef def = makeDetailDef();
+    World world(def);
+
+    const ChunkCoord cc{0, 0, 0};
+    world.loadChunk(cc, flatStoneGen, nullptr);
+    ASSERT_NE(world.getChunk(cc), nullptr);
+    EXPECT_FALSE(world.isChunkDirty(cc));
+
+    // Place a gold marker inside the chunk.
+    const WorldCoord pos(5.5, 0.5, 5.5);  // inside chunk [0, 10)³
+    world.setVoxel(pos, goldMarker());
+    EXPECT_TRUE(world.isChunkDirty(cc));
+}
+
+TEST(ArenaPlatformerMechanics, BreakDetailVoxelMarksDirty) {
+    // Removing a voxel (setting it to empty) also marks the chunk dirty.
+    LayerDef def = makeDetailDef();
+    World world(def);
+
+    const ChunkCoord cc{0, -1, 0};  // Y < 0 → stone floor from flatStoneGen
+    world.loadChunk(cc, flatStoneGen, nullptr);
+    ASSERT_NE(world.getChunk(cc), nullptr);
+    EXPECT_FALSE(world.isChunkDirty(cc));
+
+    // Break one voxel from the solid chunk.
+    const WorldCoord pos(3.5, -5.5, 3.5);
+    world.setVoxel(pos, Voxel::empty());
+    EXPECT_TRUE(world.isChunkDirty(cc));
+}
+
+TEST(ArenaPlatformerMechanics, ClearDirtyMakesChunkClean) {
+    LayerDef def = makeDetailDef();
+    World world(def);
+
+    const ChunkCoord cc{0, 0, 0};
+    world.loadChunk(cc, flatStoneGen, nullptr);
+    world.setVoxel(WorldCoord(1.5, 1.5, 1.5), goldMarker());
+    ASSERT_TRUE(world.isChunkDirty(cc));
+
+    world.clearChunkDirty(cc);
+    EXPECT_FALSE(world.isChunkDirty(cc));
+}
+
+// ── Group 3: Persistence round-trip of a player-built platform ───────────────
+
+TEST(ArenaPlatformerMechanics, PersistenceRoundTripPreservesPlayerEdits) {
+    // Generate a detail chunk, place a voxel (the "bridge"), save to disk, reload,
+    // and verify the player edit survived the evict-then-restore cycle.
+    const std::string dir = tempDir("roundtrip");
+    LayerDef def = makeDetailDef();
+    const persistence::WorldIdentity id{def.voxel_size_m, def.chunk_size_voxels};
+    persistence::WorldSave save(dir, id);
+
+    {
+        World world(def);
+        const ChunkCoord cc{3, 2, 1};
+        world.loadChunk(cc, flatStoneGen, nullptr);
+
+        // Place a bridge block (gold marker) at a specific world position.
+        const WorldCoord editPos(33.5, 20.5, 13.5);  // inside chunk [30,40)×[20,30)×[10,20)
+        world.setVoxel(editPos, goldMarker());
+        ASSERT_TRUE(world.isChunkDirty(cc));
+
+        // Save dirty chunks (as the demo does on eviction and on quit).
+        const int saved = save.saveDirtyChunks(world);
+        EXPECT_EQ(saved, 1);
+        EXPECT_FALSE(world.isChunkDirty(cc));   // flag cleared after save
+        EXPECT_TRUE(save.hasChunk(cc));
+    }
+
+    // Simulate relaunch: create a new World, prefer saved chunk over regenerating.
+    {
+        World world2(def);
+        const ChunkCoord cc{3, 2, 1};
+
+        auto loaded = save.tryLoadChunk(cc);
+        ASSERT_NE(loaded, nullptr);
+        world2.insertChunk(std::move(loaded));
+
+        // The bridge voxel must be exactly what the player placed.
+        const WorldCoord editPos(33.5, 20.5, 13.5);
+        const Voxel result = world2.getVoxel(editPos);
+        EXPECT_EQ(result.material.palette_index, 12);
+        EXPECT_NEAR(result.material.density, 100.0f, 0.001f);
+
+        // The loaded chunk is clean (the edits are already on disk, not pending).
+        EXPECT_FALSE(world2.isChunkDirty(cc));
+    }
+
+    std::filesystem::remove_all(dir);
+}
+
+TEST(ArenaPlatformerMechanics, CleanChunkIsNotSaved) {
+    // saveDirtyChunks must skip clean (generator-produced) chunks to avoid
+    // bloating the save directory with regeneratable data.
+    const std::string dir = tempDir("clean_not_saved");
+    LayerDef def = makeDetailDef();
+    const persistence::WorldIdentity id{def.voxel_size_m, def.chunk_size_voxels};
+    persistence::WorldSave save(dir, id);
+
+    World world(def);
+    world.loadChunk({0, 0, 0}, flatStoneGen, nullptr);
+    world.loadChunk({1, 0, 0}, flatStoneGen, nullptr);
+    EXPECT_FALSE(world.isChunkDirty({0, 0, 0}));
+    EXPECT_FALSE(world.isChunkDirty({1, 0, 0}));
+
+    const int saved = save.saveDirtyChunks(world);
+    EXPECT_EQ(saved, 0);
+    EXPECT_FALSE(save.hasChunk({0, 0, 0}));
+    EXPECT_FALSE(save.hasChunk({1, 0, 0}));
+
+    std::filesystem::remove_all(dir);
+}
+
+TEST(ArenaPlatformerMechanics, SaveEvictReloadRestoresEdit) {
+    // Simulate the save-then-evict pattern used by the demo when detail chunks
+    // drift past kDetailKeepRadiusM: save the dirty chunk, clear its dirty flag,
+    // unload it, then reload via insertChunk — edit must survive.
+    const std::string dir = tempDir("save_evict_reload");
+    LayerDef def = makeDetailDef();
+    const persistence::WorldIdentity id{def.voxel_size_m, def.chunk_size_voxels};
+    persistence::WorldSave save(dir, id);
+
+    World world(def);
+    const ChunkCoord cc{0, 0, 0};
+    world.loadChunk(cc, flatStoneGen, nullptr);
+
+    const WorldCoord pos(7.5, 2.5, 1.5);
+    world.setVoxel(pos, goldMarker());
+    ASSERT_TRUE(world.isChunkDirty(cc));
+
+    // Save-then-evict (mirrors the demo's detail eviction loop).
+    if (const Chunk* ch = world.getChunk(cc)) save.saveChunk(*ch);
+    world.clearChunkDirty(cc);
+    world.unloadChunk(cc);
+    EXPECT_EQ(world.getChunk(cc), nullptr);
+
+    // Reload (mirrors the demo's decomposition integration with saved-chunk check).
+    auto loaded = save.tryLoadChunk(cc);
+    ASSERT_NE(loaded, nullptr);
+    world.insertChunk(std::move(loaded));
+    ASSERT_NE(world.getChunk(cc), nullptr);
+
+    const Voxel result = world.getVoxel(pos);
+    EXPECT_EQ(result.material.palette_index, 12);
+    EXPECT_NEAR(result.material.density, 100.0f, 0.001f);
+
+    std::filesystem::remove_all(dir);
+}
+
+TEST(ArenaPlatformerMechanics, MultipleEditsInChunkAllPersist) {
+    // All voxel edits within the same chunk must survive a round-trip — not just
+    // the first one (verifies the RLE codec handles multiple distinct values).
+    const std::string dir = tempDir("multi_edit");
+    LayerDef def = makeDetailDef();
+    const persistence::WorldIdentity id{def.voxel_size_m, def.chunk_size_voxels};
+    persistence::WorldSave save(dir, id);
+
+    World world(def);
+    const ChunkCoord cc{0, 0, 0};
+    world.loadChunk(cc, flatStoneGen, nullptr);
+
+    // Place three different markers at distinct positions within the same chunk.
+    struct Edit { WorldCoord pos; uint8_t idx; float density; };
+    const Edit edits[] = {
+        { WorldCoord(1.5, 1.5, 1.5), 12, 100.0f },
+        { WorldCoord(5.5, 5.5, 5.5),  9, 800.0f },
+        { WorldCoord(8.5, 8.5, 8.5),  2, 1200.0f },
+    };
+    for (const auto& e : edits) {
+        MaterialProperties m{};
+        m.palette_index = e.idx;
+        m.density       = e.density;
+        world.setVoxel(e.pos, Voxel{m});
+    }
+    ASSERT_TRUE(world.isChunkDirty(cc));
+    save.saveDirtyChunks(world);
+
+    // Reload into a fresh world and verify every edit.
+    World world2(def);
+    auto loaded = save.tryLoadChunk(cc);
+    ASSERT_NE(loaded, nullptr);
+    world2.insertChunk(std::move(loaded));
+    for (const auto& e : edits) {
+        const Voxel v = world2.getVoxel(e.pos);
+        EXPECT_EQ(v.material.palette_index, e.idx)
+            << "palette mismatch for edit at " << e.pos.value.x;
+        EXPECT_NEAR(v.material.density, e.density, 0.001f)
+            << "density mismatch for edit at " << e.pos.value.x;
+    }
+
+    std::filesystem::remove_all(dir);
+}


### PR DESCRIPTION
## Summary
Implements Group 3 of the M7b arena platformer: player-driven voxel editing with persistence across sessions. Players can now break and place detail-layer voxels to build bridges, with all edits automatically saved to disk and restored on relaunch.

## Key Changes

**New Test Suite (`ArenaPlatformerMechanicsTest.cpp`)**
- Added 6 comprehensive unit tests for dirty-chunk tracking and persistence round-trips
- Tests verify that voxel edits mark chunks dirty, that clean chunks are not saved, and that player-built structures survive save/evict/reload cycles
- Validates RLE codec handles multiple distinct voxel values within a single chunk

**Voxel Editing & Targeting**
- Integrated DDA raycast (`VoxelRaycast`) to target resident detail-layer voxels within 8 m reach
- Left mouse breaks voxels (sets to empty); right mouse places selected material (keys 1–9)
- Collision check prevents placing voxels into the player's occupied space
- Edited chunks are immediately re-meshed and fire `on_voxel_modified` hooks

**Persistence Layer**
- Integrated `ChunkPersistence` (WorldSave) to save dirty detail chunks to `arena-save/` directory
- Dirty chunks are saved on two triggers:
  - **Eviction**: when detail chunks drift past `kDetailKeepRadiusM`, save before unload
  - **Quit**: on application exit, save all remaining dirty chunks
- On relaunch, saved chunks are preferred over freshly generated ones, preserving player edits
- Feature generators (key markers) are only applied to freshly generated chunks, not loaded saves

**Demo Integration (`07-arena-platformer/main.cpp`)**
- Added material palette selection (keys 1–9) with console feedback
- Implemented `remeshDetailChunk` and `editDetailVoxel` helpers for immediate visual feedback
- Wired save-then-evict pattern into the detail chunk eviction loop
- Integrated saved-chunk preference into decomposition result integration
- Added persistence initialization and save-on-quit logging
- Updated help text and comments to document new controls and mechanics

**Documentation**
- Updated README.md to mark M7b Group 3 tasks as complete
- Updated demo header comments to describe platformer mechanics, controls, and persistence behavior

## Notable Implementation Details
- Dirty-chunk tracking uses existing `World::isChunkDirty()` and `World::clearChunkDirty()` primitives (same as M5 demo 04)
- Save directory is created automatically by `WorldSave` if it doesn't exist
- Player-built edits are stored in RLE-compressed chunk format, avoiding bloat from regeneratable generator data
- Floating-origin camera (F mode) maintains sub-meter precision across the full 500 m arena while editing

https://claude.ai/code/session_017h14FH6d6WPYDHFe2yzTvS