### PR TITLE
Add explicit padding to MaterialProperties for determinism

### DIFF
--- a/include/plugin_api.h
+++ b/include/plugin_api.h
@@ -26,6 +26,9 @@ struct MaterialProperties {
     float   porosity             = 0.0f;  // 0.0–1.0; fraction permeable to fluid
     float   hardness             = 0.0f;  // relative resistance to removal/destruction
     uint8_t palette_index        = 0;     // index into the 256-entry visual palette (.vox compat)
+    uint8_t _pad[3]              = {};    // explicit padding — keeps memcmp-based determinism checks
+                                          // valid across GCC optimization levels. Must stay zero;
+                                          // never read by engine code.
 };
 
 // Forward declaration — full definition in src/world/Voxel.h


### PR DESCRIPTION
## Summary
Added explicit padding bytes to the `MaterialProperties` struct to ensure consistent memory layout across different GCC optimization levels, maintaining the validity of memcmp-based determinism checks.

## Key Changes
- Added 3-byte padding field (`_pad[3]`) to `MaterialProperties` struct after `palette_index`
- Initialized padding to zero with explicit default initialization
- Added documentation clarifying that padding must remain zero and is never read by engine code

## Implementation Details
The padding is necessary to maintain struct alignment and prevent compiler-dependent padding variations that could cause memcmp-based determinism validation to fail across different optimization levels. This is a common pattern for ensuring binary reproducibility in systems that rely on memory comparison for consistency checks.

https://claude.ai/code/session_01NDgNsonuGy9Z7vKD7c1DkE