### PR TITLE
Fix ProfilerTest.RecordIsThreadSafe dangling pointer on macOS

### DIFF
--- a/tests/ProfilerTest.cpp
+++ b/tests/ProfilerTest.cpp
@@ -87,7 +87,8 @@ TEST(ProfilerTest, RecordIsThreadSafe) {
     for (auto& th : threads) th.join();
     profiler().setEnabled(false);
 
-    const ProfileZoneStat* z = find(profiler().snapshot(), "mt.zone");
+    const auto snap = profiler().snapshot();
+    const ProfileZoneStat* z = find(snap, "mt.zone");
     ASSERT_NE(z, nullptr);
     EXPECT_EQ(z->calls, static_cast<uint64_t>(kThreads) * kPer);
     EXPECT_EQ(z->totalNs, static_cast<uint64_t>(kThreads) * kPer);  // 1 ns each


### PR DESCRIPTION
The snapshot temporary was destroyed before dereferencing the pointer
returned by find(), causing UB that manifested as zero-valued fields
on macOS (Clang) while silently passing on Linux (GCC).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E31hJu7ZjYowXsAPCF4aJr