### PR TITLE
M18: add 14-tutorial series covering the full engine feature surface

### DIFF
--- a/docs/tutorials/01-hello-voxel.md
+++ b/docs/tutorials/01-hello-voxel.md
@@ -1,0 +1,237 @@
+# Tutorial 01: Hello Voxel
+
+Build the engine from source, run your first demo, and understand the minimal
+code that puts a single voxel on screen.
+
+---
+
+## Prerequisites
+
+- A C++17 compiler (GCC 10+, Clang 12+, or MSVC 2019+)
+- CMake 3.20 or later
+- Git
+- A desktop GPU with OpenGL 3.3 or Metal support
+
+---
+
+## 1. Clone and build
+
+```bash
+git clone <repo-url> VoxelEngine
+cd VoxelEngine
+cmake -B build
+cmake --build build
+```
+
+The build produces:
+
+- `build/01-single-voxel` -- the demo you will run in this tutorial
+- `build/plugins/` -- shared-library plugins discovered automatically at build
+  time (no CMake edits needed)
+- The engine static library and test binaries
+
+---
+
+## 2. Run the demo
+
+```bash
+./build/01-single-voxel
+```
+
+You should see a window titled *VoxelEngine* showing a single green cube
+orbiting in front of the camera. The cube is one voxel at the world origin
+rendered with per-face brightness shading (top brightest, bottom darkest).
+
+### Fly-camera controls
+
+The demo starts in **auto-orbit** mode. Press **F** to toggle into free-camera
+mode:
+
+| Key | Action |
+|-----|--------|
+| **W / A / S / D** | Move forward / left / backward / right |
+| **Space** | Move up |
+| **Left Shift** | Move down |
+| **Mouse** | Look around (pitch clamped to +/-1.55 rad) |
+| **F** | Toggle auto-orbit / free-camera |
+| **Escape** | Quit |
+
+---
+
+## 3. Anatomy of a minimal demo
+
+Open `demos/01-single-voxel/main.cpp`. The file follows a five-step pattern
+that every demo in the engine repeats.
+
+### Step 1: Load the layer configuration
+
+```cpp
+LayerConfig layerConfig = LayerConfig::loadFromString(R"(
+layers:
+  - name: terrain
+    voxel_size_m: 1.0
+    mode: terminal
+)");
+```
+
+A `LayerConfig` describes the world's layer stack. This single-layer config
+says: "one layer called `terrain`, where each voxel is a 1-meter cube, and the
+layer is `terminal`" (meaning it is the editable leaf -- no further
+decomposition).
+
+### Step 2: Load plugins and start the engine
+
+```cpp
+PluginManager pluginManager;
+pluginManager.loadPluginsFromDirectory("plugins");
+pluginManager.wireInPlugin(voxel_plugin_init);
+
+Engine engine;
+engine.start();
+```
+
+`loadPluginsFromDirectory` scans for shared-library plugins built under
+`build/plugins/`. `wireInPlugin` links a compiled-in plugin directly (the
+example plugin that ships with the engine). The `Engine` owns the core
+lifecycle.
+
+### Step 3: Create a window and renderer
+
+```cpp
+platform::Window window(800, 600, "VoxelEngine — Hello Voxel");
+
+BgfxRenderer renderer;
+int fbW, fbH;
+window.framebufferSize(fbW, fbH);
+renderer.initialize(window.nativeHandles(),
+                    static_cast<uint32_t>(fbW),
+                    static_cast<uint32_t>(fbH));
+```
+
+The window is a thin wrapper around GLFW. The `BgfxRenderer` initializes the
+bgfx graphics backend with the window's native handles and framebuffer
+dimensions.
+
+### Step 4: Create a world and place a voxel
+
+```cpp
+World world(1, 1, 1);
+Voxel v;
+v.material.palette_index = 2;  // grass green
+v.material.density       = 1.0f;
+world.setVoxel(0, 0, 0, v);
+```
+
+`World(1, 1, 1)` creates a 1x1x1 voxel grid. Every voxel carries a
+`MaterialProperties` struct -- not a block-type ID. The `palette_index` picks
+a color from the 256-entry visual palette; `density` gives the voxel physical
+mass. Setting density above 0 makes the voxel non-empty.
+
+### Step 5: Run the game loop
+
+```cpp
+while (!window.shouldClose()) {
+    window.pollEvents();
+
+    renderer.setCameraPosition(camPos);
+    renderer.setCameraRotation(pitch, yaw, 0.0f);
+    renderer.renderWorld(world);
+    renderer.render();
+}
+```
+
+Each frame: poll input, update the camera, submit the world for rendering, and
+present. `camPos` is a `WorldCoord` (wraps `glm::dvec3` for double-precision
+world-space positions). Pitch and yaw come from mouse deltas.
+
+### Shutdown
+
+```cpp
+renderer.shutdown();
+engine.stop();
+```
+
+---
+
+## 4. The YAML layer config format
+
+The layer config is the blueprint for your world's scale structure. Each entry
+under `layers:` accepts these fields:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | string | (required) | Identifies the layer; referenced by `decompose_to`. |
+| `voxel_size_m` | double | (required) | Edge length of one voxel in meters. |
+| `mode` | string | (required) | `terminal` (editable leaf), `composite` (lazily decomposes), or `immutable` (render/collision only). |
+| `chunk_size_voxels` | int | 32 | Voxels per chunk side (the chunk is the cube of this). |
+| `view_distance_chunks` | int | 8 | Load/evict radius around the camera, in chunks. |
+
+Stack-wide validation rules enforced at startup:
+
+1. At least one layer must be defined.
+2. `voxel_size_m` values must be strictly descending across layers.
+3. Adjacent layers must have integer size ratios of at least 2:1.
+4. Every `composite` layer must name a `decompose_to` target that exists.
+
+An invalid config is a hard error at startup -- the engine exits with a
+descriptive message rather than producing undefined behavior at runtime. For
+the full set of per-layer fields and validation rules, see
+[`docs/configuration-guide.md`](../configuration-guide.md).
+
+---
+
+## 5. WorldCoord and the coordinate system
+
+All world-space positions use `WorldCoord`, a type that wraps `glm::dvec3`
+(64-bit double precision). This gives sub-millimeter accuracy at
+solar-system scales. You construct it explicitly:
+
+```cpp
+WorldCoord camPos(0.0, 2.0, 4.0);
+```
+
+The GPU only receives 32-bit floats. Before submission, all geometry is
+translated into camera-local space (the camera's `WorldCoord` is subtracted
+from every vertex), so the floats that reach the shader are always small and
+precise. For the design rationale, see
+[`docs/architecture.md`](../architecture.md) section 1.
+
+---
+
+## How to verify
+
+1. **Build and run the demo:**
+
+   ```bash
+   cmake -B build && cmake --build build
+   ./build/01-single-voxel
+   ```
+
+   You should see a green voxel. Press **F** to enter free-camera mode and fly
+   around it.
+
+2. **Run the test suite:**
+
+   ```bash
+   ctest --test-dir build
+   ```
+
+   All tests should pass. If any fail, the build environment is not set up
+   correctly.
+
+---
+
+## Key references
+
+| What | Where |
+|------|-------|
+| Demo source | `demos/01-single-voxel/main.cpp` |
+| Engine lifecycle | `include/core/Engine.h` |
+| Layer config parsing and validation | `include/core/LayerConfig.h` |
+| WorldCoord type | `include/WorldCoord.h` |
+| Plugin manager | `include/core/PluginManager.h` (see [Tutorial 02](02-your-first-plugin.md)) |
+| Voxel definition | `src/world/Voxel.h` |
+| Window wrapper | `include/platform/Window.h` |
+| Renderer | `include/renderer/BgfxRenderer.h` |
+| Full configuration reference | [`docs/configuration-guide.md`](../configuration-guide.md) |
+| Architecture overview | [`docs/architecture.md`](../architecture.md) |

--- a/docs/tutorials/02-your-first-plugin.md
+++ b/docs/tutorials/02-your-first-plugin.md
@@ -1,0 +1,313 @@
+# Tutorial 02: Your First Plugin
+
+Write a plugin that registers a custom material and a terrain generator, load
+it into a demo, and see the results on screen.
+
+---
+
+## Prerequisites
+
+- The engine builds and runs successfully (see
+  [Tutorial 01](01-hello-voxel.md))
+- Familiarity with the engine lifecycle (`Engine`, `LayerConfig`,
+  `PluginManager`, game loop)
+- A C++17 compiler
+
+---
+
+## 1. The plugin contract
+
+A plugin is a single `plugin.cpp` file placed under `plugins/<name>/`. The
+build system discovers it automatically -- no CMake edits are required. It is
+compiled into a shared library (`.so` / `.dylib` / `.dll`) and loaded at
+runtime by `PluginManager`.
+
+Every plugin must:
+
+1. Include `plugin_api.h`.
+2. Export a C-linkage function named `voxel_plugin_init`.
+3. Stamp its ABI version with `VOXEL_PLUGIN_ABI_STAMP()`.
+4. Return `0` from init on success (non-zero aborts the load).
+
+The current ABI version is **2** (`VOXEL_PLUGIN_ABI_VERSION = 2`). The engine
+checks the stamp at load time and rejects a mismatch with a diagnostic message
+rather than risking silent memory corruption.
+
+---
+
+## 2. Minimal plugin skeleton
+
+Create `plugins/my-terrain/plugin.cpp`:
+
+```cpp
+#include "plugin_api.h"
+#include "world/Voxel.h"
+
+VOXEL_PLUGIN_ABI_STAMP();
+
+extern "C" VOXEL_PLUGIN_EXPORT int voxel_plugin_init(PluginContext* ctx) {
+    // Register materials, generators, recipes here.
+    return 0;  // 0 = success
+}
+```
+
+`VOXEL_PLUGIN_EXPORT` is defined in `plugin_api.h` and resolves to
+`__declspec(dllexport)` on Windows or nothing on other platforms (C linkage
+provides symbol visibility on Linux/macOS).
+
+A plugin links **zero engine symbols**. It talks to the engine exclusively
+through the `PluginContext` function pointers and the inline helpers in
+`plugin_api.h`.
+
+---
+
+## 3. Register a material
+
+A material is a `MaterialProperties` struct -- a bag of physical values that
+simulation systems read directly. There is no block-type enum anywhere in the
+engine.
+
+```cpp
+MaterialProperties stone{};
+stone.density              = 2600.0f;   // kg/m^3 -- physics mass
+stone.hardness             = 0.8f;      // removal resistance
+stone.structural_strength  = 0.9f;      // collapse resistance
+stone.palette_index        = 1;         // visual color index
+
+ctx->register_material(ctx, "stone", stone);
+ctx->set_palette_color(ctx, 1, 0xff808080);  // ABGR: opaque gray
+```
+
+### MaterialProperties fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `density` | float | kg/m^3; drives physics mass and structural load |
+| `structural_strength` | float | Collapse resistance (PropagationSystem) |
+| `thermal_conductivity` | float | Heat spread rate (ThermalSystem) |
+| `porosity` | float | Fluid permeability [0,1] (FluidSystem) |
+| `hardness` | float | Removal resistance (RemovalAccumulator) |
+| `light_emission` | float | [0,1] emitted block light (LightingSystem) |
+| `palette_index` | uint8_t | Index into the 256-entry visual palette |
+
+For the full property-to-system mapping, see
+[Tutorial 03](03-materials-and-properties.md).
+
+### Palette colors: ABGR format
+
+Colors are packed as `0xAABBGGRR`. Alpha `0xff` is opaque; alpha below `0xff`
+makes the material translucent (routed into the alpha render pass -- this is
+how water and glass are drawn).
+
+---
+
+## 4. Write a layer generator
+
+A `LayerGeneratorFn` fills a chunk's voxel grid from scratch. It receives the
+chunk's world-space origin, the grid size (voxels per side), and a flat output
+array of `grid_size^3` voxels in row-major order (x fastest).
+
+```cpp
+void my_terrain(WorldCoord chunk_origin, int grid_size,
+                Voxel* out_voxels, void* user_data) {
+    for (int z = 0; z < grid_size; ++z)
+        for (int y = 0; y < grid_size; ++y)
+            for (int x = 0; x < grid_size; ++x) {
+                int idx = x + grid_size * (y + grid_size * z);
+                double wy = chunk_origin.value.y + y;
+                if (wy < 4.0)
+                    out_voxels[idx].material = stone;
+                else
+                    out_voxels[idx] = Voxel::empty();
+            }
+}
+```
+
+This generator creates a flat stone floor: every voxel below world-y 4.0 is
+stone; everything above is empty (air).
+
+### The determinism rule
+
+Generators must be **pure functions of (position, seed)**. No `rand()`, no
+`time()`, no global mutable state. Streamed chunks regenerate on demand -- if
+the generator is not deterministic, terrain will tear at chunk seams or change
+on reload.
+
+For deterministic randomness, use the header-only RNG helpers in
+`plugin_api.h`:
+
+```cpp
+uint64_t voxel_rng_next(uint64_t* state);       // splitmix64
+float    voxel_rng_norm(uint64_t* state);        // uniform [0,1)
+uint64_t voxel_seed_mix(uint64_t a, uint64_t b); // fold two ints into a seed
+```
+
+### Voxel indexing
+
+The flat array uses `x + grid_size * (y + grid_size * z)` -- x is the fastest
+axis, z the slowest. This layout matches every demo, plugin, and the engine's
+internal chunk storage.
+
+---
+
+## 5. Register the generator
+
+Back in `voxel_plugin_init`, register the generator for the layer named
+`"terrain"`:
+
+```cpp
+ctx->register_layer_generator(ctx, "terrain", my_terrain, nullptr);
+```
+
+The fourth argument is `user_data` -- an opaque pointer the engine passes back
+to every call of `my_terrain`. Pass `nullptr` when you do not need it, or use
+it to thread configuration (voxel sizes, noise seeds, etc.) into the generator
+without global state.
+
+---
+
+## 6. Complete plugin
+
+Here is `plugins/my-terrain/plugin.cpp` in full:
+
+```cpp
+#include "plugin_api.h"
+#include "world/Voxel.h"
+
+VOXEL_PLUGIN_ABI_STAMP();
+
+namespace {
+
+MaterialProperties g_stone{};
+
+void my_terrain(WorldCoord chunk_origin, int grid_size,
+                Voxel* out_voxels, void* /*user_data*/) {
+    for (int z = 0; z < grid_size; ++z)
+        for (int y = 0; y < grid_size; ++y)
+            for (int x = 0; x < grid_size; ++x) {
+                int idx = x + grid_size * (y + grid_size * z);
+                double wy = chunk_origin.value.y + y;
+                if (wy < 4.0)
+                    out_voxels[idx].material = g_stone;
+                else
+                    out_voxels[idx] = Voxel::empty();
+            }
+}
+
+}  // namespace
+
+extern "C" VOXEL_PLUGIN_EXPORT int voxel_plugin_init(PluginContext* ctx) {
+    // Material.
+    g_stone.density             = 2600.0f;
+    g_stone.hardness            = 0.8f;
+    g_stone.structural_strength = 0.9f;
+    g_stone.palette_index       = 1;
+
+    ctx->register_material(ctx, "stone", g_stone);
+    ctx->set_palette_color(ctx, 1, 0xff808080);  // opaque gray (ABGR)
+
+    // Generator.
+    ctx->register_layer_generator(ctx, "terrain", my_terrain, nullptr);
+
+    return 0;
+}
+```
+
+---
+
+## 7. Build
+
+No CMake edits are needed. Rebuild:
+
+```bash
+cmake -B build
+cmake --build build
+```
+
+The build system discovers `plugins/my-terrain/plugin.cpp` automatically and
+produces `build/plugins/my-terrain.so` (or `.dylib` / `.dll`).
+
+---
+
+## 8. Load the plugin from a demo
+
+### Option A: Load from disk at runtime
+
+```cpp
+PluginManager pluginManager;
+auto id = pluginManager.loadPlugin(VOXEL_PLUGIN_PATH);  // returns PluginId
+```
+
+`loadPlugin` opens the shared library, reads the ABI stamp, and calls
+`voxel_plugin_init`. If the ABI version does not match, the load aborts with a
+diagnostic. `VOXEL_PLUGIN_PATH` is typically defined at build time by CMake.
+
+### Option B: Wire in a compiled-in plugin
+
+For tests or demos that compile the plugin source directly:
+
+```cpp
+pluginManager.wireInPlugin(voxel_plugin_init);
+```
+
+This calls `voxel_plugin_init` directly without loading a shared library.
+No ABI version check is performed (compiled-in code is always in sync).
+
+### Retrieve the generator for chunk-streamed worlds
+
+When streaming terrain in a demo, you retrieve the registered generator by
+layer name:
+
+```cpp
+LayerGeneratorFn generator = nullptr;
+void* generatorUserData = nullptr;
+for (const auto& g : pluginManager.layerGenerators()) {
+    if (g.layer_name == "terrain") {
+        generator = g.fn;
+        generatorUserData = g.user_data;
+    }
+}
+```
+
+See `demos/03-plugin-driven-world/main.cpp` for the full streaming pattern
+that uses this generator to fill chunks on demand.
+
+---
+
+## How to verify
+
+1. **Build and run:**
+
+   ```bash
+   cmake -B build && cmake --build build
+   ./build/03-plugin-driven-world
+   ```
+
+   You should see a flat terrain surface generated by the `base-terrain` plugin.
+   Press **F** to enter free-camera mode and fly over the landscape.
+
+2. **Runtime plugin toggling:** In demo 03, press **P** to load/unload the
+   water plugin at runtime. When water is unloaded, the world is exactly the
+   base-terrain heightmap. When loaded, flat blue water floods every empty
+   voxel up to a fixed sea level. This demonstrates that plugins are fully
+   hot-swappable.
+
+3. **Test your own plugin:** Replace `VOXEL_BASE_PLUGIN_PATH` with the path to
+   your `my-terrain.so` or wire it in with `wireInPlugin`. You should see a
+   flat gray stone floor 4 voxels high.
+
+---
+
+## Key references
+
+| What | Where |
+|------|-------|
+| Plugin API (all registration points) | `include/plugin_api.h` |
+| ABI version and stamp | `include/plugin_api.h` (`VOXEL_PLUGIN_ABI_VERSION`, `VOXEL_PLUGIN_ABI_STAMP`) |
+| Example compiled-in plugin | `src/plugins/ExamplePlugin.cpp` |
+| Base-terrain plugin (disk-loaded) | `plugins/base-terrain/plugin.cpp` |
+| Plugin-driven demo | `demos/03-plugin-driven-world/main.cpp` |
+| Material system design | [`docs/architecture.md`](../architecture.md) section 5 |
+| Plugin system design | [`docs/architecture.md`](../architecture.md) section 8 |
+| Material deep dive | [Tutorial 03](03-materials-and-properties.md) |
+| Recipe-driven composition | [Tutorial 04](04-composition-recipes.md) |

--- a/docs/tutorials/03-materials-and-properties.md
+++ b/docs/tutorials/03-materials-and-properties.md
@@ -1,0 +1,259 @@
+# Tutorial 03: Materials and Properties
+
+Define materials whose physical properties drive every simulation system in the
+engine -- physics mass, mining time, structural collapse, fluid flow, heat
+spread, and lighting -- all without touching engine code.
+
+---
+
+## Prerequisites
+
+- The engine builds and runs successfully (see
+  [Tutorial 01](01-hello-voxel.md))
+- You know how to write and register a plugin (see
+  [Tutorial 02](02-your-first-plugin.md))
+- Familiarity with `MaterialProperties`, `register_material`, and
+  `set_palette_color`
+
+---
+
+## 1. The material-driven philosophy
+
+Voxels in this engine are **not** block-type IDs. There is no
+`enum BlockType { Stone, Dirt, Water, ... }`. Instead, every voxel carries a
+`MaterialProperties` struct -- a bag of physical values. Simulation systems
+read these values and respond accordingly:
+
+- The **PhysicsSystem** reads `density` to compute mass.
+- The **RemovalAccumulator** reads `hardness` to determine mining time.
+- The **PropagationSystem** reads `structural_strength` to decide whether a
+  structure collapses.
+- The **FluidSystem** reads `porosity` to decide whether fluid seeps through.
+- The **ThermalSystem** reads `thermal_conductivity` to spread heat.
+- The **LightingSystem** reads `light_emission` to emit block light.
+- The **Renderer** reads `palette_index` to look up the visual color.
+
+To create a new material -- volcanic glass, packed ice, steel alloy -- you
+fill a `MaterialProperties` struct and register it. No engine system needs to
+be modified. The simulation reacts to the properties you assign.
+
+For the full design rationale, see
+[`docs/architecture.md`](../architecture.md) section 5.
+
+---
+
+## 2. MaterialProperties field reference
+
+Every field, its type, its default, and the engine system that consumes it:
+
+| Field | Type | Default | Consumer system |
+|-------|------|---------|-----------------|
+| `density` | float | 0.0f | PhysicsSystem (mass, structural load) |
+| `hardness` | float | 0.0f | RemovalAccumulator (mining time) |
+| `structural_strength` | float | 0.0f | PropagationSystem (collapse resistance) |
+| `porosity` | float | 0.0f | FluidSystem (fluid permeability, range [0,1]) |
+| `thermal_conductivity` | float | 0.0f | ThermalSystem (heat spread rate) |
+| `light_emission` | float | 0.0f | LightingSystem (block light, range [0,1]) |
+| `palette_index` | uint8_t | 0 | Renderer (visual color lookup) |
+
+### Special values
+
+- **`density = 0`** makes a voxel empty (`Voxel::isEmpty()` returns true). The
+  renderer skips it entirely.
+- **`hardness = -1.0f`** makes a material indestructible. The
+  `RemovalAccumulator` refuses to accumulate removal work against it, so the
+  voxel can never be mined. This is how bedrock works.
+- **`light_emission > 0`** causes the LightingSystem to treat the voxel as a
+  light source. The value scales the emitted brightness.
+
+---
+
+## 3. Palette colors: the ABGR format
+
+The engine's 256-entry palette stores colors in **ABGR** format, packed into a
+`uint32_t`: `0xAABBGGRR`.
+
+| Component | Byte position | Example (opaque gray) |
+|-----------|---------------|-----------------------|
+| Alpha | `AA` | `0xff` (fully opaque) |
+| Blue | `BB` | `0x80` |
+| Green | `GG` | `0x80` |
+| Red | `RR` | `0x80` |
+
+Set a palette color from a plugin:
+
+```cpp
+ctx->set_palette_color(ctx, 1, 0xff808080);  // opaque gray at index 1
+```
+
+### Translucency
+
+Set alpha below `0xff` to make a material translucent. The mesh builder skips
+per-face brightness shading on translucent voxels and draws them in a separate
+blended render pass. This is how water and glass are rendered:
+
+```cpp
+ctx->set_palette_color(ctx, 10, 0x50f0e8d8);  // alpha 0x50 = translucent
+```
+
+Palette index 0 is reserved for empty voxels and is never rendered.
+
+---
+
+## 4. Multi-material strata example
+
+The `material-showcase` plugin demonstrates a layered terrain where each
+stratum has distinct physical properties. Here is the registration pattern:
+
+```cpp
+// Topsoil: light, weak, porous, fast to mine.
+MaterialProperties topsoil{};
+topsoil.density             = 1200.0f;
+topsoil.hardness            = 0.2f;
+topsoil.structural_strength = 0.1f;
+topsoil.porosity            = 0.5f;
+topsoil.palette_index       = 2;
+
+ctx->register_material(ctx, "topsoil", topsoil);
+ctx->set_palette_color(ctx, 2, 0xff2d6b30);  // opaque brown-green
+
+// Stone: medium density, hard, strong, impermeable.
+MaterialProperties stone{};
+stone.density             = 2600.0f;
+stone.hardness            = 0.6f;
+stone.structural_strength = 0.9f;
+stone.porosity            = 0.0f;
+stone.palette_index       = 3;
+
+ctx->register_material(ctx, "stone", stone);
+ctx->set_palette_color(ctx, 3, 0xff808080);  // opaque gray
+
+// Iron ore: very dense, very hard, slight light emission.
+MaterialProperties iron{};
+iron.density             = 7800.0f;
+iron.hardness            = 0.9f;
+iron.structural_strength = 0.95f;
+iron.light_emission      = 0.05f;
+iron.palette_index       = 4;
+
+ctx->register_material(ctx, "iron", iron);
+ctx->set_palette_color(ctx, 4, 0xff404880);  // dark reddish-brown
+
+// Bedrock: indestructible floor.
+MaterialProperties bedrock{};
+bedrock.density             = 3000.0f;
+bedrock.hardness            = -1.0f;  // indestructible
+bedrock.structural_strength = 1.0f;
+bedrock.palette_index       = 5;
+
+ctx->register_material(ctx, "bedrock", bedrock);
+ctx->set_palette_color(ctx, 5, 0xff303030);  // dark gray
+```
+
+### Placing strata in the generator
+
+A layer generator places these materials by world-y height:
+
+```cpp
+void strata_terrain(WorldCoord chunk_origin, int n,
+                    Voxel* out, void* /*user_data*/) {
+    for (int z = 0; z < n; ++z)
+        for (int y = 0; y < n; ++y)
+            for (int x = 0; x < n; ++x) {
+                int idx = x + n * (y + n * z);
+                double wy = chunk_origin.value.y + y;
+
+                if      (wy < 0.0) out[idx].material = bedrock;
+                else if (wy < 6.0) out[idx].material = stone;
+                else if (wy < 8.0) out[idx].material = topsoil;
+                else               out[idx] = Voxel::empty();
+            }
+}
+```
+
+The result: dig down through soft topsoil (clears quickly), hit stone (takes
+longer), then iron ore (very slow), and finally bedrock (impossible). Each
+stratum's behavior emerges purely from its property values.
+
+---
+
+## 5. Runtime material lookup
+
+Registered materials can be looked up by name at runtime:
+
+```cpp
+MaterialProperties mat = pluginManager.material("stone");
+```
+
+This is useful in demos and tools that need to inspect or display material
+properties (the HUD in `08-material-matters` uses this to show the targeted
+voxel's hardness and density).
+
+---
+
+## 6. Material registration in context
+
+Materials are registered through the `PluginContext` during plugin init:
+
+```cpp
+ctx->register_material(ctx, "stone", stone);
+```
+
+The string ID (`"stone"`) is how recipes, feature generators, and tooling
+refer to the material. The engine deep-copies the `MaterialProperties` value.
+
+Palette colors are set separately:
+
+```cpp
+ctx->set_palette_color(ctx, 3, 0xff808080);
+```
+
+This two-step pattern (register the material, then set its palette color)
+keeps the material's physical identity separate from its visual appearance.
+The same material could have different visual representations in different
+contexts.
+
+For the complete recipe-book reference on creating voxels (including composite
+blocks with boundary overrides), see
+[`docs/creating-voxels.md`](../creating-voxels.md).
+
+---
+
+## How to verify
+
+1. **Build and run the material-matters demo:**
+
+   ```bash
+   cmake -B build && cmake --build build
+   ./build/08-material-matters
+   ```
+
+2. **Observe material-driven behavior:**
+   - Aim at different strata and hold left mouse to mine. Topsoil clears
+     almost instantly. Stone takes noticeably longer. Iron ore is very slow.
+     Bedrock never clears at all.
+   - The HUD displays the targeted voxel's `hardness`, `density`, and
+     `structural_strength` -- all read directly from its `MaterialProperties`.
+   - The wireframe highlight around the targeted voxel ramps toward red as
+     removal work accrues, giving visual feedback of the hardness difference.
+
+3. **Place different materials:** Press **1** through **6** to select a
+   material, then right-click to place it. Place a diamond block and try to
+   mine it back -- it is hard but removable. Place bedrock -- it is
+   indestructible.
+
+---
+
+## Key references
+
+| What | Where |
+|------|-------|
+| MaterialProperties struct | `include/plugin_api.h` |
+| Voxel definition | `src/world/Voxel.h` |
+| Palette and default colors | `src/renderer/Palette.h` |
+| Material-showcase plugin (strata) | `plugins/material-showcase/plugin.cpp` |
+| Material-matters demo | `demos/08-material-matters/main.cpp` |
+| Material system design | [`docs/architecture.md`](../architecture.md) section 5 |
+| Creating voxels recipe book | [`docs/creating-voxels.md`](../creating-voxels.md) |
+| Plugin registration | [Tutorial 02](02-your-first-plugin.md) |
+| Composition recipes | [Tutorial 04](04-composition-recipes.md) |

--- a/docs/tutorials/04-composition-recipes.md
+++ b/docs/tutorials/04-composition-recipes.md
@@ -1,0 +1,359 @@
+# Tutorial 04: Composition Recipes
+
+Build a procedural multi-scale world where macro voxels decompose into richly
+detailed interiors using recipes -- material distributions, noise fields,
+boundary overrides, and feature overlays.
+
+---
+
+## Prerequisites
+
+- The engine builds and runs successfully (see
+  [Tutorial 01](01-hello-voxel.md))
+- You can write and register a plugin (see
+  [Tutorial 02](02-your-first-plugin.md))
+- You understand `MaterialProperties` and palette colors (see
+  [Tutorial 03](03-materials-and-properties.md))
+
+---
+
+## 1. Voxel modes: composite, terminal, immutable
+
+Every layer in a `LayerConfig` has a **mode** that controls its behavior:
+
+| Mode | Behavior |
+|------|----------|
+| `terminal` | The editable leaf layer. Players build and mine here. No further decomposition. |
+| `composite` | A macro voxel that **lazily decomposes** into a finer child layer on approach or interaction. Must name a `decompose_to` target. |
+| `immutable` | Render and collision only. Never modified, never decomposed, never persisted. Used for distant backdrops. |
+
+A typical multi-scale world stacks composites on top of a terminal leaf:
+
+```yaml
+layers:
+  - name: blocks
+    voxel_size_m: 8.0
+    mode: composite
+    decompose_to: terrain
+    chunk_size_voxels: 4
+    view_distance_chunks: 7
+  - name: terrain
+    voxel_size_m: 1.0
+    mode: terminal
+    chunk_size_voxels: 32
+    view_distance_chunks: 5
+```
+
+When the player approaches an 8 m "blocks" voxel, the engine decomposes it
+into an 8x8x8 grid of 1 m "terrain" voxels. The **recipe** registered for
+the "blocks" layer controls what that interior looks like.
+
+---
+
+## 2. The decomposition chain
+
+Decomposition is **cascading** and **lazy**: a macro voxel decomposes one
+layer at a time, and only when something needs its interior (camera proximity
+or player interaction). In a three-layer stack
+(`continental -> regional -> terrain`), an approaching player first triggers
+the continental-to-regional decomposition, then regional-to-terrain.
+
+Each step is driven by a **recipe** -- a declarative description of what the
+interior contains. The engine never jumps scales in a single step.
+
+When the player moves away, the fine-grained child chunks are collapsed back
+to coarse macro voxels, keeping the resident mesh count bounded.
+
+---
+
+## 3. Writing a RecipeDesc
+
+A `RecipeDesc` is a flat POD struct that describes how a composite macro voxel
+fills its child grid when it decomposes. It has four parts:
+
+1. **Interior distribution** -- the bulk material fill
+2. **Boundary overrides** -- face-specific material shells (top, bottom, side)
+3. **Feature overlays** -- structures stamped into the grid after filling
+4. **Seed parameters** -- values cascaded to the child layer's generation
+
+### Interior: DistributionDesc
+
+The interior distribution defines the bulk material fill. It supports multiple
+weighted materials arranged spatially by a named noise field:
+
+```cpp
+MaterialWeight mats[] = {
+    {"granite", 0.8f},
+    {"basalt",  0.15f},
+    {"quartz",  0.05f}
+};
+
+DistributionDesc interior{};
+interior.materials      = mats;
+interior.material_count = 3;
+interior.noise_id       = "fbm";  // spatial arrangement
+
+RecipeParam noiseParams[] = {
+    {"scale", RecipeParamKind::Number, 4.0, nullptr}
+};
+interior.noise_params      = noiseParams;
+interior.noise_param_count = 1;
+```
+
+Built-in noise IDs: `"value"`, `"fbm"`, `"ridged"`, `"worley"`. Pass
+`nullptr` for `noise_id` to use the default (`"value"`). The noise field
+determines which material is placed at each position -- the weights are
+thresholds on the noise value, so heavier-weighted materials occupy more of
+the volume.
+
+### Boundary overrides: BoundaryDesc
+
+Boundary overrides paint the outer shell of the child grid with a different
+material than the interior. Each face direction (`top`, `bottom`, `side`) can
+have its own override:
+
+```cpp
+BoundaryDesc top{};
+top.present = true;
+top.depth   = 1;  // 1 child-voxel layer from the top face
+
+MaterialWeight soilMats[] = {{"soil", 1.0f}};
+top.distribution.materials      = soilMats;
+top.distribution.material_count = 1;
+```
+
+`depth` controls how many child-voxel layers inward from the face are
+replaced. A depth of 1 creates a one-voxel-thick skin; depth 2-3 creates a
+thicker cap.
+
+**Overlap order at edges and corners:** `bottom -> side -> top`. When two
+boundaries compete for the same voxel at an edge or corner, the top override
+wins. This means a grass-cap always covers the rim of a block, even at the
+edges.
+
+For a walkthrough of building a Minecraft-style grass block using boundary
+overrides, see [`docs/creating-voxels.md`](../creating-voxels.md) section 4.
+
+### Feature overlays: FeatureRef
+
+Features are structures stamped **in-place** into the child grid after the
+interior and boundaries are filled. They operate on the already-populated
+voxel array, carving or adding material:
+
+```cpp
+RecipeParam caveParams[] = {
+    {"threshold", RecipeParamKind::Number, 0.45, nullptr},
+    {"scale",     RecipeParamKind::Number, 8.0,  nullptr}
+};
+
+RecipeParam oreParams[] = {
+    {"density", RecipeParamKind::Number, 0.02, nullptr}
+};
+
+FeatureRef features[] = {
+    {"cave",     caveParams, 2},
+    {"ore_vein", oreParams,  1}
+};
+```
+
+Features are applied in array order. In this example, caves carve first, then
+ore veins are threaded through the remaining solid material.
+
+### Seed parameters: RecipeParam
+
+Seed parameters bias the child layer's generation. They are cascaded
+downward through the decomposition chain:
+
+```cpp
+RecipeParam seedParams[] = {
+    {"cave_density", RecipeParamKind::Number, 0.3, nullptr}
+};
+```
+
+The engine also injects `"__altitude"` automatically into every recipe's
+effective parameters -- this is the decomposing macro voxel's world-space
+height, so features can vary with depth without the plugin computing it.
+
+---
+
+## 4. Assembling the complete recipe
+
+```cpp
+RecipeDesc recipe{};
+recipe.interior = interior;               // bulk distribution
+recipe.features      = features;          // feature overlays
+recipe.feature_count = 2;
+recipe.top    = topBoundary;              // face overrides
+recipe.bottom = bottomBoundary;
+recipe.side   = sideBoundary;
+recipe.seed_parameters      = seedParams;
+recipe.seed_parameter_count = 1;
+
+ctx->register_recipe(ctx, "blocks", &recipe);  // deep-copied by engine
+```
+
+The engine deep-copies the `RecipeDesc` at registration. The plugin's arrays
+do not need to outlive the `register_recipe` call.
+
+---
+
+## 5. Writing a feature generator
+
+A `FeatureGeneratorFn` operates **in-place** on an already-filled voxel grid.
+It receives the effective parameters (the recipe entry's own params merged
+with inherited seed parameters) and a deterministic per-decomposition seed:
+
+```cpp
+void cave_feature(WorldCoord origin, double voxel_size, int grid_size,
+                  Voxel* inout,
+                  const RecipeParam* params, size_t count,
+                  uint64_t seed, void* user_data) {
+    double threshold = recipe_param_num(params, count, "threshold", 0.45);
+
+    for (int z = 0; z < grid_size; ++z)
+        for (int y = 0; y < grid_size; ++y)
+            for (int x = 0; x < grid_size; ++x) {
+                WorldCoord pos(origin.value.x + x * voxel_size,
+                               origin.value.y + y * voxel_size,
+                               origin.value.z + z * voxel_size);
+                uint64_t s = voxel_seed_mix(seed,
+                                 x + grid_size * (y + grid_size * z));
+                float n = voxel_rng_norm(&s);
+                if (n < threshold)
+                    inout[x + grid_size * (y + grid_size * z)] = Voxel::empty();
+            }
+}
+
+ctx->register_feature_generator(ctx, "cave", cave_feature, nullptr);
+```
+
+`recipe_param_num` is a header-only helper in `plugin_api.h` that looks up a
+named parameter by key and returns a fallback if not found.
+
+The same determinism rule as layer generators applies: the same seed must
+produce the same result. Use `voxel_rng_next`, `voxel_rng_norm`, and
+`voxel_seed_mix` for all randomness.
+
+---
+
+## 6. Noise functions
+
+### Consuming built-in noise
+
+A plugin can resolve a built-in (or plugin-registered) noise function by ID:
+
+```cpp
+NoiseFn valueNoise = ctx->resolve_noise(ctx, "value");
+float n = valueNoise(pos, seed, params, param_count, nullptr);
+```
+
+`resolve_noise` returns `nullptr` if the ID is not registered, so check
+before calling.
+
+### Registering custom noise
+
+```cpp
+float my_noise(WorldCoord pos, uint64_t seed,
+               const RecipeParam* params, size_t count, void* user_data) {
+    // Return a scalar in [0,1)
+    uint64_t s = voxel_seed_mix(seed,
+        static_cast<uint64_t>(pos.value.x * 1000.0));
+    return voxel_rng_norm(&s);
+}
+
+ctx->register_noise(ctx, "my_noise", my_noise, nullptr);
+```
+
+A registered noise ID overrides a built-in of the same name. Noise functions
+are sampled at **world positions** (not chunk-local positions), so adjacent
+macro voxels' child grids are seamless.
+
+---
+
+## 7. Deterministic RNG helpers
+
+All three helpers are defined inline in `plugin_api.h` and compile with no
+engine dependency:
+
+```cpp
+uint64_t voxel_rng_next(uint64_t* state);       // splitmix64
+float    voxel_rng_norm(uint64_t* state);        // uniform [0,1)
+uint64_t voxel_seed_mix(uint64_t a, uint64_t b); // fold two ints into a seed
+```
+
+Use `voxel_seed_mix` to derive a per-voxel seed from the chunk seed and the
+voxel's flat index:
+
+```cpp
+uint64_t s = voxel_seed_mix(seed, x + grid_size * (y + grid_size * z));
+float roll = voxel_rng_norm(&s);
+```
+
+This guarantees that the same world position produces the same random
+sequence on every run, on every platform, regardless of thread scheduling.
+
+---
+
+## 8. Driving the decomposition
+
+In a demo or game, the `DecompositionManager` drives the cascade. It
+decomposes composite voxels within an approach radius of the camera and
+collapses distant ones to keep the resident chunk count bounded:
+
+```cpp
+DecompositionManager decompMgr(world, pluginManager, layerConfig, kWorldSeed);
+
+// In the game loop, each frame:
+auto diffs = decompMgr.tick(camPos, approachRadius,
+                            loadPerFrame, decompPerFrame, applyPerFrame);
+```
+
+The budgets (`loadPerFrame`, `decompPerFrame`, `applyPerFrame`) control how
+much work the manager does per frame to avoid stalls. See
+`demos/09-recipe-built-voxel/main.cpp` for the full integration pattern.
+
+---
+
+## How to verify
+
+1. **Build and run the recipe demo:**
+
+   ```bash
+   cmake -B build && cmake --build build
+   ./build/09-recipe-built-voxel
+   ```
+
+2. **Observe recipe-driven decomposition:**
+   - Fly toward a macro voxel. As you approach, it decomposes into a detailed
+     interior: soil cap on top, granite/basalt bulk, cave voids, and ore veins.
+   - Dig into a decomposed block to see the cross-section: the boundary
+     overrides (soil on top), the noise-driven material distribution (granite
+     and basalt), and the carved cave features.
+
+3. **Verify determinism:** Fly away so the fine terrain collapses back to
+   coarse blocks. Return to the same area -- every block regenerates
+   identically (byte-for-byte). The decomposition is a pure function of
+   position and seed.
+
+4. **Depth-dependent caves:** Dig a shaft straight down. Caves near the
+   surface are sparse; deeper caves become denser. This is the
+   engine-cascaded `"__altitude"` parameter at work -- the cave feature
+   reads the macro voxel's height from the effective params and adjusts its
+   threshold.
+
+---
+
+## Key references
+
+| What | Where |
+|------|-------|
+| RecipeDesc, DistributionDesc, BoundaryDesc, FeatureRef | `include/plugin_api.h` |
+| NoiseFn and RNG helpers | `include/plugin_api.h` |
+| Recipe-world plugin (full recipe example) | `plugins/recipe-world/plugin.cpp` |
+| Recipe-built-voxel demo | `demos/09-recipe-built-voxel/main.cpp` |
+| DecompositionManager | `src/world/DecompositionManager.h` |
+| Composition recipe design | [`docs/architecture.md`](../architecture.md) section 6 |
+| Creating voxels recipe book | [`docs/creating-voxels.md`](../creating-voxels.md) |
+| Layer config (composite mode) | [`docs/configuration-guide.md`](../configuration-guide.md) |
+| Material registration | [Tutorial 02](02-your-first-plugin.md) |
+| Material properties | [Tutorial 03](03-materials-and-properties.md) |

--- a/docs/tutorials/05-multi-face-blocks.md
+++ b/docs/tutorials/05-multi-face-blocks.md
@@ -1,0 +1,307 @@
+# Tutorial 05: Multi-Face Blocks via Recipes
+
+Give your voxels visual variety -- green grass on top, brown dirt on the sides
+-- using boundary overrides in the engine's recipe system. No engine changes
+required; everything lives in a plugin.
+
+---
+
+## Prerequisites
+
+- Engine built and running ([Tutorial 01](01-hello-voxel.md))
+- Comfortable writing a plugin ([Tutorial 02](02-your-first-plugin.md))
+- Familiar with materials and palette colors ([Tutorial 03](03-materials-and-properties.md))
+- Understanding of composite vs. terminal layers ([Tutorial 04](04-composition-recipes.md))
+
+---
+
+## 1. The problem: one voxel, one color
+
+A single terminal voxel renders as one solid color with per-face brightness
+shading (top brightest, bottom darkest). The mesh builder looks up
+`palette::color(palette_index)` and emits that color for every visible face.
+There is no texture atlas, no UV coordinates -- the vertex format is
+`{float x, y, z; uint32_t abgr}`.
+
+So how do you build a Minecraft-style grass block where the top is green and
+the sides are brown?
+
+---
+
+## 2. The engine-native answer: composite blocks with boundary overrides
+
+A `composite` voxel is a large macro block that stays atomic until something
+needs its interior. When it decomposes, a **recipe** fills the resulting child
+grid with materials. The recipe can attach **boundary overrides** to three face
+groups -- `top` (+Y), `bottom` (-Y), and `side` (all four lateral faces) --
+that paint the outer shell of the child grid with a different material than the
+interior, to a configurable depth.
+
+The result: a macro block that decomposes into a green cap on top, brown on the
+sides, and brown (or stone) filling the interior. Viewed from outside, it looks
+exactly like a multi-face block.
+
+---
+
+## 3. BoundaryDesc: the face override struct
+
+Each face group is described by a `BoundaryDesc` (defined in
+[`include/plugin_api.h`](../../include/plugin_api.h)):
+
+```cpp
+struct BoundaryDesc {
+    DistributionDesc distribution;  // material distribution for this face
+    int              depth   = 1;   // child-voxel layers inward from face
+    bool             present = false; // false = face uses interior distribution
+};
+```
+
+| Field | Purpose |
+|-------|---------|
+| `present` | When `false` (default), this face group uses the interior distribution -- no override. Set to `true` to activate the override. |
+| `depth` | How many child-voxel layers inward from the face are replaced by this override's distribution. `1` = a one-voxel-thick skin; `2` = a two-voxel topsoil. |
+| `distribution` | A `DistributionDesc` specifying which materials fill this face band, with optional noise. |
+
+The distribution itself:
+
+```cpp
+struct DistributionDesc {
+    const MaterialWeight* materials         = nullptr;
+    size_t                material_count    = 0;
+    const char*           noise_id          = nullptr;  // nullptr => built-in "value"
+    const RecipeParam*    noise_params      = nullptr;
+    size_t                noise_param_count = 0;
+};
+```
+
+And a `RecipeDesc` carries three boundary fields:
+
+```cpp
+struct RecipeDesc {
+    DistributionDesc interior;       // the bulk distribution
+    // ...
+    BoundaryDesc     top;            // +Y face
+    BoundaryDesc     bottom;         // -Y face
+    BoundaryDesc     side;           // all four lateral faces
+    // ...
+};
+```
+
+---
+
+## 4. Overlap order: bottom, side, top
+
+At edges and corners where two or more boundary zones overlap, the engine
+applies them in a fixed order: **bottom, then side, then top**. Top wins at the
+rim. This means the grass cap covers the top corners even where side boundaries
+also claim those voxels.
+
+```
+         top wins here
+            v v v
+        +---+---+---+
+        | T | T | T |   <- top boundary (depth 1)
+        +---+---+---+
+        | S |   | S |   <- side boundary (depth 1)
+        +---+---+---+
+        | S |   | S |
+        +---+---+---+
+        | B | B | B |   <- bottom boundary (depth 1)
+        +---+---+---+
+
+  Cross-section of an 4x4 child grid.
+  T = top override, S = side override, B = bottom override.
+  Interior cells use the recipe's interior distribution.
+```
+
+---
+
+## 5. Step-by-step: building a grass block
+
+This walkthrough builds a composite grass block: green top, dirt sides and
+interior.
+
+### 5.1 Register the materials
+
+```cpp
+MaterialProperties dirt{};
+dirt.density = 1400.0f;
+dirt.hardness = 0.3f;
+dirt.palette_index = 5;
+ctx->register_material(ctx, "dirt", dirt);
+ctx->set_palette_color(ctx, 5, 0xff2d5e87);  // ABGR brown
+
+MaterialProperties grass_surface{};
+grass_surface.density = 1200.0f;
+grass_surface.hardness = 0.2f;
+grass_surface.palette_index = 6;
+ctx->register_material(ctx, "grass_surface", grass_surface);
+ctx->set_palette_color(ctx, 6, 0xff30a040);  // ABGR green
+```
+
+Palette colors are **ABGR** packed `uint32_t`: `0xAABBGGRR`. Alpha `0xff` is
+opaque; alpha below `0xff` makes the material translucent.
+
+### 5.2 Define the interior distribution
+
+The interior is the bulk of the block -- everything not covered by a boundary
+override. Here, 100% dirt:
+
+```cpp
+MaterialWeight interiorMats[] = {{"dirt", 1.0f}};
+DistributionDesc interior{};
+interior.materials = interiorMats;
+interior.material_count = 1;
+```
+
+### 5.3 Define the top boundary
+
+The green surface cap, one child-voxel layer deep:
+
+```cpp
+BoundaryDesc top{};
+top.present = true;
+top.depth = 1;
+MaterialWeight topMats[] = {{"grass_surface", 1.0f}};
+top.distribution.materials = topMats;
+top.distribution.material_count = 1;
+```
+
+### 5.4 Assemble and register the recipe
+
+```cpp
+RecipeDesc recipe{};
+recipe.interior = interior;
+recipe.top = top;
+// bottom and side left as default (present = false -> uses interior)
+ctx->register_recipe(ctx, "blocks", &recipe);
+```
+
+Because `bottom` and `side` are left with `present = false`, those faces use
+the interior distribution (dirt). Only the top gets the green override.
+
+The engine deep-copies the recipe at registration, so the local arrays need not
+outlive the `register_recipe` call.
+
+### 5.5 Wire up the layer config
+
+The composite layer must declare `mode: composite` and `decompose_to:` a child
+layer in the YAML config:
+
+```yaml
+layers:
+  - name: blocks
+    voxel_size_m: 8.0
+    mode: composite
+    decompose_to: terrain
+    chunk_size_voxels: 8
+  - name: terrain
+    voxel_size_m: 1.0
+    mode: terminal
+    interactive: true
+```
+
+When the player approaches a `blocks` macro voxel, it decomposes into an 8x8x8
+grid of 1 m child voxels: the top layer green, everything else dirt. For full
+details on layer configs, see
+[`docs/configuration-guide.md`](../configuration-guide.md).
+
+---
+
+## 6. Going richer
+
+### Multi-material interiors with noise
+
+Instead of a single dirt fill, mix materials using weighted noise:
+
+```cpp
+MaterialWeight interiorMats[] = {{"granite", 0.7f}, {"basalt", 0.3f}};
+interior.materials = interiorMats;
+interior.material_count = 2;
+interior.noise_id = "fbm";
+```
+
+The `noise_id` selects a spatial noise function. Built-in options: `"value"`,
+`"fbm"`, `"ridged"`, `"worley"`. Register custom noise via
+`ctx->register_noise()`, or consume a built-in from a plugin via
+`ctx->resolve_noise()`.
+
+### Thicker caps
+
+For a multi-voxel topsoil layer, increase `depth`:
+
+```cpp
+recipe.top.depth = 3;  // three child-voxel layers of grass
+```
+
+### Snow-capped mountain block
+
+Set `top.depth = 2` with a snow material for a thick snow cap:
+
+```cpp
+MaterialWeight snowMats[] = {{"snow", 1.0f}};
+recipe.top.distribution.materials = snowMats;
+recipe.top.distribution.material_count = 1;
+recipe.top.depth = 2;
+```
+
+### Exposed-rock side faces
+
+Activate the side boundary with a rock material:
+
+```cpp
+recipe.side.present = true;
+recipe.side.depth = 1;
+MaterialWeight rockMats[] = {{"exposed_rock", 1.0f}};
+recipe.side.distribution.materials = rockMats;
+recipe.side.distribution.material_count = 1;
+```
+
+### Ice shell block
+
+Combine all three boundaries for an ice-shell block with a different interior:
+
+```cpp
+recipe.top.present = true;
+recipe.bottom.present = true;
+recipe.side.present = true;
+// All three use ice; interior uses packed snow or air
+```
+
+Remember the overlap order: at the top rim, the top boundary wins over the side
+boundary. At the bottom rim, the side boundary wins over the bottom boundary.
+
+For the complete recipe-book reference, including feature overlays and seed
+parameters, see [`docs/creating-voxels.md`](../creating-voxels.md) section 4.
+
+---
+
+## How to verify
+
+1. Build and run the recipe demo:
+
+   ```bash
+   cmake -B build && cmake --build build
+   ./build/09-recipe-built-voxel
+   ```
+
+   Fly toward a composite block. It should decompose into a child grid with
+   visibly different colors on the top face versus the sides.
+
+2. To see the boundary override in a custom plugin, add the grass block recipe
+   from section 5 to your plugin, configure the two-layer YAML from section
+   5.5, and observe the green cap on decomposition.
+
+---
+
+## Key references
+
+| What | Where |
+|------|-------|
+| BoundaryDesc, RecipeDesc, DistributionDesc | [`include/plugin_api.h`](../../include/plugin_api.h) |
+| MaterialWeight struct | [`include/plugin_api.h`](../../include/plugin_api.h) |
+| Recipe-world plugin (ships a boundary-override recipe) | `plugins/recipe-world/plugin.cpp` |
+| Full recipe-book reference (grass block and beyond) | [`docs/creating-voxels.md`](../creating-voxels.md) section 4 |
+| Layer config fields and validation | [`include/core/LayerConfig.h`](../../include/core/LayerConfig.h) |
+| Configuration guide | [`docs/configuration-guide.md`](../configuration-guide.md) |
+| Architecture: composition recipes | [`docs/architecture.md`](../architecture.md) section 6 |

--- a/docs/tutorials/06-importing-voxel-assets.md
+++ b/docs/tutorials/06-importing-voxel-assets.md
@@ -1,0 +1,296 @@
+# Tutorial 06: Importing Voxel Assets
+
+Bring models from MagicaVoxel, Qubicle, or Blockbench into the engine. This
+tutorial covers the import/export workflow for each supported format and the
+round-trip editing cycle.
+
+---
+
+## Prerequisites
+
+- Engine built and running ([Tutorial 01](01-hello-voxel.md))
+- Comfortable writing a plugin ([Tutorial 02](02-your-first-plugin.md))
+- Familiar with materials and palette colors ([Tutorial 03](03-materials-and-properties.md))
+
+---
+
+## 1. Supported formats
+
+| Format | Extension | Editor | Scope |
+|--------|-----------|--------|-------|
+| MagicaVoxel | `.vox` | [MagicaVoxel](https://ephtracy.github.io/) | Single-layer, 256-entry RGBA palette, max 256x256x256 per object (auto-chunked for larger volumes) |
+| Qubicle Binary | `.qb` | [Qubicle](https://www.qubicle.com/) | Single-layer, palette-color |
+| Blockbench | `.bbmodel` | [Blockbench](https://www.blockbench.net/) | Textured blocks with per-face images |
+
+All formats map to the engine's palette-indexed voxel model. Extended
+`MaterialProperties` fields (density, hardness, structural_strength, etc.)
+are **not** preserved in `.vox` or `.qb` round-trips -- only `palette_index`
+survives.
+
+---
+
+## 2. MagicaVoxel workflow
+
+### 2.1 Create and export
+
+Create a model in MagicaVoxel and save it as a `.vox` file. The file uses a
+256-entry RGBA palette; each voxel references one index.
+
+### 2.2 Import via Engine (high-level)
+
+The simplest path uses the `Engine` class, which handles file I/O, palette
+mapping, and chunk creation:
+
+```cpp
+engine.importVox("model.vox", "editor", WorldCoord(0, 0, 0));
+// args: file path, target layer name, world-space anchor
+```
+
+The engine prefers a plugin-registered importer for `.vox` if one exists;
+otherwise it falls back to the built-in `VoxImporter`.
+
+### 2.3 Import via VoxImporter (standalone)
+
+For direct control, use `VoxImporter` from `src/io/VoxImporter.h`:
+
+```cpp
+#include "io/VoxImporter.h"
+
+VoxImporter importer;
+importer.load("model.vox", *layer, WorldCoord(0, 0, 0), pluginManager);
+```
+
+Each placed voxel receives:
+- `palette_index` set directly from the `.vox` color index
+- Other `MaterialProperties` fields copied from the first `PluginManager`
+  material whose `palette_index` matches; zero-defaults if none is registered
+
+The file's authored RGBA colors are installed into the engine's shared visual
+palette so imported voxels render with their original colors.
+
+### 2.4 The VoxFile format
+
+The low-level parse API in `src/io/VoxImporter.h`:
+
+```cpp
+namespace vox {
+
+struct VoxFile {
+    std::vector<VoxModel>      models;
+    std::array<RgbaColor, 256> palette{};
+};
+
+// Parse raw .vox bytes. Returns false on bad magic / truncated data.
+bool parse(const uint8_t* data, size_t size, VoxFile& out);
+
+}  // namespace vox
+```
+
+Key constraints:
+- Max 256x256x256 per object; larger volumes are auto-chunked into multiple
+  objects with `nTRN` transform nodes encoding world offsets
+- Palette entry 0 is unused (index 0 = empty in the `.vox` convention)
+- When the file has no RGBA chunk, the built-in MagicaVoxel default palette is
+  used
+
+---
+
+## 3. Export from the engine
+
+### 3.1 Via Engine
+
+```cpp
+engine.exportVox("editor", minCorner, maxCorner, "output.vox");
+```
+
+The engine emits a `LOG_WARN` when any voxel in the region carries non-default
+extended properties (density, hardness, etc.) because the `.vox` format silently
+drops them.
+
+### 3.2 Via VoxExporter (standalone)
+
+```cpp
+#include "io/VoxExporter.h"
+
+VoxExporter exporter;
+exporter.save("output.vox", *layer, WorldCoord(0, 0, 0), WorldCoord(4, 4, 4));
+```
+
+Regions larger than 256 voxels on any axis are auto-chunked: each 256-cubed
+sub-volume becomes a separate SIZE+XYZI object with an `nTRN` transform node.
+
+### 3.3 Computing the bounding box
+
+To export all placed voxels, compute the bounding box from the layer's resident
+chunks:
+
+```cpp
+int cs = layer->chunkSizeVoxels();
+double vsz = layer->voxelSizeM();
+int minX = INT_MAX, minY = INT_MAX, minZ = INT_MAX;
+int maxX = INT_MIN, maxY = INT_MIN, maxZ = INT_MIN;
+
+for (const auto& [cc, _] : editorLayer->chunks()) {
+    minX = std::min(minX, static_cast<int>(cc.x));
+    minY = std::min(minY, static_cast<int>(cc.y));
+    minZ = std::min(minZ, static_cast<int>(cc.z));
+    maxX = std::max(maxX, static_cast<int>(cc.x));
+    maxY = std::max(maxY, static_cast<int>(cc.y));
+    maxZ = std::max(maxZ, static_cast<int>(cc.z));
+}
+
+WorldCoord expMin(minX * cs * vsz, minY * cs * vsz, minZ * cs * vsz);
+WorldCoord expMax((maxX + 1) * cs * vsz, (maxY + 1) * cs * vsz, (maxZ + 1) * cs * vsz);
+```
+
+---
+
+## 4. Qubicle Binary (.qb) workflow
+
+The `.qb` format follows the same pattern as `.vox`:
+
+```cpp
+// Import
+engine.importQb("model.qb", "editor", WorldCoord(0, 0, 0));
+
+// Export
+engine.exportQb("editor", minCorner, maxCorner, "output.qb");
+```
+
+The same lossy-property warning applies: only `palette_index` survives the
+round-trip.
+
+---
+
+## 5. Blockbench workflow
+
+Blockbench models (`.bbmodel`) support per-face textures. Importing them
+requires a plugin that uses the texture pipeline.
+
+### 5.1 Register the importer in plugin init
+
+```cpp
+// In plugin init:
+ctx->register_importer(ctx, "bbmodel", &importBlockbench, ctx);
+```
+
+### 5.2 Handle textures in the importer
+
+A `.bbmodel` file embeds textures as base64 data URIs. The importer registers
+them as in-memory image data:
+
+```cpp
+ctx->register_texture_data(ctx, texture_id, png_data, png_size);
+```
+
+Then bind the textures to material faces:
+
+```cpp
+ctx->set_material_faces(ctx, palette_index, top_tex, bottom_tex, side_tex, tiling_factor);
+```
+
+Where:
+- `top_tex` is the texture_id for the +Y face
+- `bottom_tex` is the texture_id for the -Y face
+- `side_tex` is the texture_id shared by all four lateral faces
+- `tiling_factor` is tiles per world meter (pass `1` for one image per face)
+
+A null face string leaves that face unbound, rendering with the white tile
+fallback. The binding keys on `palette_index`, not voxel size, so one texture
+is scale-agnostic.
+
+---
+
+## 6. Round-trip editing
+
+The typical workflow:
+
+1. **Import** a `.vox` model into a terminal layer
+2. **Edit** voxels in-engine (place, remove, modify)
+3. **Export** back to `.vox` for further editing in MagicaVoxel
+
+**Lossy-property warning:** extended `MaterialProperties` fields (density,
+hardness, structural_strength, thermal_conductivity, porosity,
+light_emission) are not preserved in `.vox` or `.qb` format. Only
+`palette_index` survives the round-trip. If your workflow depends on these
+properties, re-apply them via a plugin after re-importing.
+
+---
+
+## 7. Creating test assets procedurally
+
+You can build and export test models entirely in code, without an external
+editor:
+
+```cpp
+#include "core/LayerConfig.h"
+#include "world/World.h"
+#include "world/Layer.h"
+#include "io/VoxExporter.h"
+
+LayerConfig config = LayerConfig::loadFromString(R"(
+layers:
+  - name: editor
+    voxel_size_m: 1.0
+    mode: terminal
+    chunk_size_voxels: 16
+)");
+
+World world(config);
+Layer* layer = world.layer("editor");
+layer->loadChunk({0, 0, 0}, nullptr);
+
+// Place voxels...
+Voxel v;
+v.material.palette_index = 2;
+v.material.density = 1.0f;
+for (int x = 0; x < 4; ++x)
+    for (int y = 0; y < 4; ++y)
+        for (int z = 0; z < 4; ++z)
+            layer->setVoxel(WorldCoord(x, y, z), v);
+
+// Export
+VoxExporter exporter;
+exporter.save("test_model.vox", *layer, WorldCoord(0, 0, 0), WorldCoord(4, 4, 4));
+```
+
+This is useful for automated tests and procedural content pipelines.
+
+---
+
+## How to verify
+
+1. **MagicaVoxel round-trip:**
+
+   ```bash
+   cmake -B build && cmake --build build
+   ./build/06-magicavoxel-round-trip
+   ```
+
+   The demo imports a `.vox` file, displays it in-engine, and lets you press
+   **E** to export the result. Open the exported file in MagicaVoxel to
+   confirm the round-trip preserved geometry and palette colors.
+
+2. **Textured blocks:**
+
+   ```bash
+   ./build/15-textured-blocks
+   ```
+
+   This demo shows Blockbench-style textured blocks with per-face images
+   rendered via the texture atlas pipeline.
+
+---
+
+## Key references
+
+| What | Where |
+|------|-------|
+| VoxImporter (load API, VoxFile parse) | `src/io/VoxImporter.h` |
+| VoxExporter (save API, auto-chunking) | `src/io/VoxExporter.h` |
+| Engine import/export wrappers | [`include/core/Engine.h`](../../include/core/Engine.h) |
+| Plugin importer/exporter registration | [`include/plugin_api.h`](../../include/plugin_api.h) (`register_importer`, `register_exporter`) |
+| Texture registration (in-memory) | [`include/plugin_api.h`](../../include/plugin_api.h) (`register_texture_data`, `set_material_faces`) |
+| MagicaVoxel round-trip demo | `demos/06-magicavoxel-round-trip/main.cpp` |
+| Textured blocks demo | `demos/15-textured-blocks/main.cpp` |
+| Blockbench plugin | `plugins/blockbench/plugin.cpp` |

--- a/docs/tutorials/06-importing-voxel-assets.md
+++ b/docs/tutorials/06-importing-voxel-assets.md
@@ -27,6 +27,42 @@ All formats map to the engine's palette-indexed voxel model. Extended
 are **not** preserved in `.vox` or `.qb` round-trips -- only `palette_index`
 survives.
 
+### Choosing a tool
+
+**MagicaVoxel** is the best starting point for most content. It is free, has a
+mature sculpting/painting UI designed specifically for voxels, and its `.vox`
+format is the engine's primary interchange format with full round-trip
+import/export support. Choose MagicaVoxel when you are building solid-color
+voxel models -- characters, props, terrain stamps, or anything where one
+palette color per voxel is enough. Its 256-entry palette maps directly to the
+engine's `palette_index`, so what you see in the editor is what you get
+in-engine. The main limitation is the 256x256x256 size cap per object (the
+engine auto-chunks larger volumes, but the editor itself enforces this bound).
+
+**Qubicle** is a commercial alternative to MagicaVoxel with stronger
+multi-matrix (multi-object) editing and a more traditional 3D-modelling
+workflow. Choose Qubicle if you prefer its UI, need multi-matrix editing with
+named parts, or already have a `.qb` asset library. The engine's `.qb` support
+is functionally equivalent to `.vox` -- same palette-color scope, same
+lossy-property caveat on round-trip.
+
+**Blockbench** is the right choice when you need **per-face textures** rather
+than a single solid color per voxel. It is free and open-source, and its
+`.bbmodel` format embeds PNG textures that the engine's `blockbench` plugin
+maps onto voxel faces via the texture atlas. Choose Blockbench for
+Minecraft-style painted blocks where the top, bottom, and sides each show a
+different image (e.g. a grass block with a green top, brown sides, and a dirt
+bottom). The trade-off: `.bbmodel` import requires the `blockbench` plugin and
+the M15 texture pipeline, so it is a heavier integration than plain `.vox`.
+
+| Use case | Recommended tool |
+|----------|-----------------|
+| Solid-color models, props, characters | MagicaVoxel |
+| Multi-object scenes, named parts | Qubicle |
+| Per-face textured blocks (grass, crates, bricks) | Blockbench |
+| Rapid prototyping (free, zero setup) | MagicaVoxel |
+| Existing `.qb` asset library | Qubicle |
+
 ---
 
 ## 2. MagicaVoxel workflow

--- a/docs/tutorials/07-multi-layer-worlds.md
+++ b/docs/tutorials/07-multi-layer-worlds.md
@@ -1,0 +1,339 @@
+# Tutorial 07: Multi-Layer Worlds
+
+Design worlds with multiple voxel scales -- coarse terrain far away,
+fine-grained detail up close. This tutorial covers layer stack planning,
+validation rules, streaming configuration, and two worked examples.
+
+---
+
+## Prerequisites
+
+- Engine built and running ([Tutorial 01](01-hello-voxel.md))
+- Comfortable writing a plugin ([Tutorial 02](02-your-first-plugin.md))
+- Understanding of composite vs. terminal modes ([Tutorial 04](04-composition-recipes.md))
+- Familiar with boundary overrides ([Tutorial 05](05-multi-face-blocks.md))
+
+---
+
+## 1. Planning a layer stack
+
+A multi-layer world is a stack of voxel grids at different scales. Each layer
+has its own voxel size, streaming radius, and role:
+
+- **Composite** layers are coarse macro voxels that lazily decompose into a
+  finer child layer via a recipe. They provide the large-scale silhouette.
+- **Terminal** layers are the editable leaf -- player-modifiable voxels at the
+  finest scale.
+- **Immutable** layers are render-and-collision only. They are never modified,
+  decomposed, or persisted. Use them for static backdrops that never change.
+
+The stack is defined in a YAML config and loaded via `LayerConfig::loadFromFile`
+or `LayerConfig::loadFromString` (see
+[`docs/configuration-guide.md`](../configuration-guide.md) for the full field
+reference).
+
+---
+
+## 2. LayerDef fields
+
+Each entry under `layers:` accepts the following fields, defined in
+[`include/core/LayerConfig.h`](../../include/core/LayerConfig.h):
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `name` | string | (required) | Layer identifier; referenced by `decompose_to`. |
+| `voxel_size_m` | double | (required) | Edge length of one voxel in meters. |
+| `mode` | `composite` / `immutable` / `terminal` | (required) | Layer role (see above). |
+| `decompose_to` | string | -- | Child layer name (composite only). |
+| `chunk_size_voxels` | int | 32 | Voxels per chunk side (the chunk is this value cubed). |
+| `view_distance_chunks` | int | 8 | Load/evict radius around the camera, in chunks. |
+| `resident_chunk_budget` | int | 0 | Per-layer cap on resident chunks (0 = unlimited). The manager evicts farthest-first clean chunks to fit; near and dirty chunks are pinned. |
+| `decompose_distance_m` | double | (unset) | Distance at which this layer's macro voxels decompose. Unset = falls back to the single radius passed to `DecompositionManager::tick()`. Setting it per layer **decouples the cascade**: reveal a coarse silhouette far out, build the fine grid only up close. |
+| `streaming_shape` | `box` / `sphere` / `shell` | `box` | Shape of the camera-centered streaming volume. |
+| `shell_thickness_chunks` | int | 1 | Band width for `shell` shape (inner radius = `view_distance_chunks - shell_thickness_chunks`). |
+| `interactive` | bool | false | Marks the one layer the single-layer World API (get/setVoxel, dirty tracking, persistence, picking) targets. At most one layer may set this. |
+
+The mode enum (`VoxelMode`): `composite`, `immutable`, `terminal`.
+The shape enum (`StreamingShape`): `box`, `sphere`, `shell`.
+
+---
+
+## 3. Validation rules
+
+The engine enforces these rules at config load time. An invalid config is a
+hard error at startup -- the engine throws `std::runtime_error` with a
+descriptive message.
+
+1. **At least one layer** must be defined.
+2. **`voxel_size_m` strictly descending** -- each layer must have a smaller
+   voxel size than the one above it.
+3. **Adjacent-layer size ratio is a whole integer >= 2** -- a parent voxel must
+   tile cleanly into child voxels (e.g. 8.0 / 1.0 = 8 is fine; 8.0 / 3.0 is
+   rejected).
+4. **Every composite layer's `decompose_to`** must name a layer that exists in
+   the config.
+5. **At most one `interactive: true`** -- two or more is a hard error. When
+   none is flagged, the engine defaults to the first terminal layer.
+
+---
+
+## 4. The `interactive` flag
+
+In a multi-layer world, only one layer is the player's edit target. The
+`interactive` flag explicitly declares which layer the World API
+(`getVoxel`/`setVoxel`, dirty tracking, persistence, picking) forwards to.
+
+Without the flag, the engine defaults to the first terminal layer. Set it
+explicitly when your edit layer is mid-stack:
+
+```yaml
+layers:
+  - name: blocks
+    voxel_size_m: 8.0
+    mode: composite
+    decompose_to: terrain
+  - name: terrain
+    voxel_size_m: 1.0
+    mode: terminal
+    interactive: true    # player edits happen here
+```
+
+---
+
+## 5. Per-layer streaming configuration
+
+### view_distance_chunks and resident_chunk_budget
+
+Each layer streams independently. `view_distance_chunks` controls how far from
+the camera chunks are loaded; `resident_chunk_budget` caps memory by evicting
+distant clean chunks.
+
+For deep stacks, budget the coarsest layers tightly (they cover large areas with
+few chunks) and give the finest layer a larger budget (many small chunks near the
+player):
+
+```yaml
+  - name: blocks
+    view_distance_chunks: 4
+    resident_chunk_budget: 256
+  - name: terrain
+    view_distance_chunks: 6
+    resident_chunk_budget: 2048
+```
+
+### decompose_distance_m
+
+Decouples the cascade trigger from the streaming radius. Set a large value on
+the coarsest composite to reveal its silhouette far out, and a small value on
+finer composites to defer expensive decomposition until the player is close:
+
+```yaml
+  - name: macro
+    voxel_size_m: 16.0
+    mode: composite
+    decompose_to: blocks
+    decompose_distance_m: 200.0    # silhouette visible at 200 m
+  - name: blocks
+    voxel_size_m: 4.0
+    mode: composite
+    decompose_to: terrain
+    decompose_distance_m: 60.0     # detail grid only within 60 m
+```
+
+### Streaming volume shapes
+
+- **`box`** (default): isotropic 3D Chebyshev cube. Works for most block games
+  with no vertical bias.
+- **`sphere`**: Euclidean ball. Excludes the cube corners -- good for games
+  where the player looks in all directions equally.
+- **`shell`**: a thin Euclidean band resident only at range. Perfect for distant
+  backdrops that never need interior detail -- the inner volume is empty, saving
+  memory.
+
+```yaml
+streaming_volume:
+  shape: shell
+  shell_thickness_chunks: 2
+```
+
+---
+
+## 6. Worked example 1: 3-layer Minecraft-like
+
+A classic block game with three scales: macro terrain blocks at 8 m, a
+mid-scale backdrop at 2 m, and the editable 1 m terrain.
+
+```yaml
+layers:
+  - name: blocks
+    voxel_size_m: 8.0
+    mode: composite
+    decompose_to: terrain
+    chunk_size_voxels: 8
+    view_distance_chunks: 4
+    resident_chunk_budget: 256
+  - name: backdrop
+    voxel_size_m: 2.0
+    mode: immutable
+    chunk_size_voxels: 8
+    view_distance_chunks: 6
+    resident_chunk_budget: 512
+  - name: terrain
+    voxel_size_m: 1.0
+    mode: terminal
+    chunk_size_voxels: 8
+    view_distance_chunks: 6
+    resident_chunk_budget: 2048
+    interactive: true
+```
+
+The `blocks` layer provides the large-scale landform. As the player approaches,
+macro voxels decompose into 8x8x8 grids of 1 m terminal voxels via the recipe
+system. The `backdrop` layer is immutable scenery that never changes -- distant
+mountains, ocean floor, sky islands.
+
+### Wiring up in code
+
+```cpp
+LayerConfig layerConfig = LayerConfig::loadFromFile("world.yaml");
+
+PluginManager pluginManager;
+pluginManager.loadPluginsFromDirectory("plugins");
+
+World world(layerConfig);
+Engine engine;
+engine.init(pluginManager, world);
+
+BgfxRenderer renderer;
+// ... initialize renderer ...
+engine.setRenderer(&renderer);
+
+constexpr uint64_t kWorldSeed = 42;
+DecompositionManager decompMgr(world, pluginManager, layerConfig, kWorldSeed);
+engine.setDecompositionManager(&decompMgr);
+```
+
+### Tick and render
+
+```cpp
+// Each frame:
+auto diffs = decompMgr.tick(camPos, approachRadius,
+                            loadPerFrame, decompPerFrame, applyPerFrame);
+// Process diffs: build/destroy meshes for new/evicted chunks...
+
+// Render coarsest first:
+for (const auto& layerName : {"backdrop", "blocks", "terrain"}) {
+    Layer* lyr = world.layer(layerName);
+    for (const auto& [cc, mesh] : meshStores[layerName])
+        renderer.renderChunk(mesh, lyr->getChunk(cc)->origin(),
+                             lyr->voxelSizeM(), lyr->chunkSizeVoxels());
+}
+```
+
+For worlds with large coarse layers, increase the far clip plane so distant
+geometry is not culled:
+
+```cpp
+renderer.setFarClip(1200.0f);
+```
+
+---
+
+## 7. Worked example 2: zero-gravity flying game
+
+A space game with a distant immutable backdrop shell and a small playable island.
+
+```yaml
+layers:
+  - name: backdrop
+    voxel_size_m: 4.0
+    mode: immutable
+    chunk_size_voxels: 16
+    view_distance_chunks: 10
+    resident_chunk_budget: 512
+    streaming_volume:
+      shape: shell
+      shell_thickness_chunks: 2
+  - name: island
+    voxel_size_m: 1.0
+    mode: terminal
+    chunk_size_voxels: 16
+    view_distance_chunks: 6
+    resident_chunk_budget: 1024
+    streaming_volume:
+      shape: box
+    interactive: true
+```
+
+The `backdrop` uses a `shell` streaming volume -- only the outer band of chunks
+is resident, forming a distant asteroid field or nebula. The `island` is a `box`
+volume centered on the player, containing the mineable playspace.
+
+The `sphere` shape for the backdrop would also work, but `shell` saves
+significant memory by not loading interior chunks that the player never reaches.
+
+### Layer access
+
+```cpp
+Layer* island = world.layer("island");
+Layer* backdrop = world.layer("backdrop");
+```
+
+---
+
+## 8. Multi-layer rendering
+
+Render layers from coarsest to finest so that fine detail overlays coarse
+geometry correctly:
+
+```cpp
+for (const auto& layerName : renderOrder) {
+    Layer* lyr = world.layer(layerName);
+    double vsm = lyr->voxelSizeM();
+    int csvx = lyr->chunkSizeVoxels();
+    for (const auto& [cc, mesh] : meshStores[layerName])
+        renderer.renderChunk(mesh, lyr->getChunk(cc)->origin(), vsm, csvx);
+}
+```
+
+The `renderChunk` method takes the layer's `voxelSizeM()` so each layer renders
+at its correct world scale. Chunk meshes are built in chunk-local units (1 voxel
+= 1 unit); the voxel size scales them to world space.
+
+---
+
+## How to verify
+
+1. **Decompose on approach:**
+
+   ```bash
+   cmake -B build && cmake --build build
+   ./build/05-decompose-on-approach
+   ```
+
+   Fly toward a composite block and watch it decompose into finer child voxels.
+   Fly away and watch the child chunks evict (the composite block reappears as
+   a single color).
+
+2. **Beyond blocks:**
+
+   ```bash
+   ./build/16-beyond-blocks
+   ```
+
+   This demo shows a multi-layer world with streaming volume shapes and the
+   shell backdrop pattern.
+
+---
+
+## Key references
+
+| What | Where |
+|------|-------|
+| LayerDef, VoxelMode, StreamingShape | [`include/core/LayerConfig.h`](../../include/core/LayerConfig.h) |
+| Layer config fields and validation | [`docs/configuration-guide.md`](../configuration-guide.md) section A |
+| DecompositionManager (tick, cascade) | `src/world/DecompositionManager.h` |
+| Engine setup for multi-layer | [`include/core/Engine.h`](../../include/core/Engine.h) |
+| Decompose-on-approach demo | `demos/05-decompose-on-approach/main.cpp` |
+| Beyond-blocks demo (shell, sphere) | `demos/16-beyond-blocks/main.cpp` |
+| Architecture: multi-layer design | [`docs/architecture.md`](../architecture.md) |

--- a/docs/tutorials/08-camera-raycasting-interaction.md
+++ b/docs/tutorials/08-camera-raycasting-interaction.md
@@ -1,0 +1,351 @@
+# Tutorial 08: Camera, Raycasting, and Interaction
+
+Aim at voxels, break them, place new ones, and render visual feedback including
+a mining-laser beam. This tutorial covers the three primitives every interactive
+voxel game needs: camera control, picking, and world edits.
+
+---
+
+## Prerequisites
+
+- Engine built and running ([Tutorial 01](01-hello-voxel.md))
+- Comfortable writing a plugin ([Tutorial 02](02-your-first-plugin.md))
+- Familiar with materials and palette colors ([Tutorial 03](03-materials-and-properties.md))
+- Understanding of the World API and WorldCoord ([Tutorial 01](01-hello-voxel.md), section 5)
+
+---
+
+## 1. Camera modes
+
+### Fly-camera
+
+Set the camera position and rotation each frame via the renderer:
+
+```cpp
+renderer.setCameraPosition(camPos);           // WorldCoord (double precision)
+renderer.setCameraRotation(pitch, yaw, 0.0f); // radians
+```
+
+`camPos` is a `WorldCoord` wrapping `glm::dvec3`. The GPU only receives 32-bit
+floats -- before submission, all geometry is translated into camera-local space
+so the floats that reach the shader are always small and precise.
+
+### Walk-mode (G toggle)
+
+Many demos toggle between fly-camera and walk-mode with the **G** key.
+Walk-mode uses the AABB collision primitive to resolve the player against solid
+voxels:
+
+```cpp
+#include "world/VoxelCollision.h"
+
+voxelcollide::MoveResult mr = voxelcollide::moveAABB(
+    world,
+    {playerCenter, kPlayerHalf},   // AABB: center + half-extents
+    delta                          // displacement this frame
+);
+playerCenter = mr.position;
+grounded = mr.grounded;
+```
+
+`MoveResult` reports the resolved position and whether the player is resting on
+a surface:
+
+```cpp
+struct MoveResult {
+    WorldCoord position;          // resolved center after the move
+    bool       grounded = false;  // resting on a solid surface (blocked along gravity)
+    bool       hitX = false, hitY = false, hitZ = false;
+};
+```
+
+The collision is substepped (no step larger than half a voxel) so the player
+cannot tunnel through thin geometry at speed. The `grounded` flag is true when
+the move was blocked along the gravity vector -- use it to gate jumping.
+
+---
+
+## 2. Building a ray from the camera
+
+To pick voxels, cast a ray from the camera position along the look direction.
+Compute the look direction from pitch and yaw:
+
+```cpp
+float cp = std::cos(pitch), sp = std::sin(pitch);
+float cy = std::cos(yaw),   sy = std::sin(yaw);
+glm::dvec3 lookDir{cp * sy, sp, cp * cy};
+```
+
+The ray origin is `camPos` (the camera's `WorldCoord`).
+
+---
+
+## 3. Raycasting / voxel picking
+
+The `voxelcast::raycast` API performs DDA grid traversal in double precision
+against the world's resident terminal voxels:
+
+```cpp
+#include "world/VoxelRaycast.h"
+
+voxelcast::RayHit hit = voxelcast::raycast(world, camPos, lookDir, kReachM);
+```
+
+Where `kReachM` is the maximum ray distance in meters (e.g. `8.0` for
+standard reach).
+
+### The RayHit struct
+
+```cpp
+struct RayHit {
+    bool                  hit;       // false if nothing solid within reach
+    chunkmath::VoxelCoord voxel;     // solid voxel struck (removal target)
+    chunkmath::VoxelCoord adjacent;  // empty cell on entry face (placement target)
+    glm::ivec3            normal;    // face normal pointing back toward ray origin
+    double                distance;  // world-space distance to hit
+};
+```
+
+| Field | Usage |
+|-------|-------|
+| `hit` | Check this first. When `false`, the ray found nothing solid within reach. |
+| `voxel` | The coordinates of the solid voxel that was struck. Pass this to the removal path. |
+| `adjacent` | The empty cell the ray entered the hit voxel from. Pass this to the placement path. It is guaranteed empty. |
+| `normal` | The face direction the ray entered from (e.g. `{0, 1, 0}` for a hit on the top face). |
+| `distance` | World-space distance from the ray origin to the hit point. |
+
+The traversal uses `WorldCoord` (double precision), not float. Cells in
+non-resident chunks read as empty, so the ray passes through unstreamed regions.
+
+---
+
+## 4. Removing a voxel
+
+When the player triggers removal (e.g. left-click) and the raycast hit a solid
+voxel, remove it via the plugin API choke point:
+
+```cpp
+if (hit.hit) {
+    WorldCoord center = chunkmath::voxelCenter(hit.voxel, world.voxelSizeM());
+    Voxel empty = Voxel::empty();
+    ctx->apply_edit(ctx, center, &empty);
+}
+```
+
+`apply_edit` routes through the engine's single edit choke point
+(`NetworkManager::applyEdit`), which:
+1. Sets the voxel in the world
+2. Fires all `on_voxel_modified` hooks
+3. Replicates the edit to peers in multiplayer
+
+This is the same path every local and network edit takes. Using `apply_edit`
+instead of `world.setVoxel` directly ensures hooks fire, persistence works, and
+multiplayer replication is correct.
+
+### Manual path (without plugin context)
+
+If you need direct control (e.g. in a demo's main loop without a plugin
+context):
+
+```cpp
+if (hit.hit) {
+    WorldCoord center = chunkmath::voxelCenter(hit.voxel, world.voxelSizeM());
+    Voxel oldVox = world.getVoxel(center);
+    world.setVoxel(center, Voxel::empty());
+
+    // Fire modification hooks:
+    Voxel empty = Voxel::empty();
+    for (const auto& h : pluginManager.voxelModifiedHooks())
+        if (h.fn) h.fn(center, &oldVox, &empty, kLocalPlayer, h.user_data);
+
+    // Remesh the affected chunk
+}
+```
+
+---
+
+## 5. Placing a voxel
+
+Use `hit.adjacent` -- the empty cell on the entry face -- as the placement
+target:
+
+```cpp
+if (hit.hit) {
+    WorldCoord placePos = chunkmath::voxelCenter(hit.adjacent, world.voxelSizeM());
+    Voxel placed;
+    placed.material = pluginManager.material("stone");
+    ctx->apply_edit(ctx, placePos, &placed);
+}
+```
+
+The placed voxel gets its full `MaterialProperties` from the material registry,
+so it participates in physics, mining, structural simulation, and rendering.
+
+---
+
+## 6. Voxel highlight (targeting outline)
+
+Draw a wireframe box around the targeted voxel to show the player what they are
+aiming at:
+
+```cpp
+if (hit.hit) {
+    renderer.drawVoxelHighlight(
+        chunkmath::voxelCenter(hit.voxel, world.voxelSizeM()),
+        static_cast<float>(world.voxelSizeM()),
+        0xff00ffff,    // ABGR color (yellow)
+        progress       // -1.0f = no progress bar, 0.0-1.0 = mining ramp
+    );
+}
+```
+
+The highlight is depth-tested (no depth write) and drawn as lines over the
+scene.
+
+### The progress ramp
+
+The `progress` parameter controls a visual mining cue:
+
+- **-1.0** (default): plain outline at the given color, no progress shown.
+- **0.0 to 1.0**: the outline ramps from the given color toward red as removal
+  work accrues. A harder material takes longer to fill the ramp.
+
+---
+
+## 7. Mining with RemovalAccumulator
+
+For held-to-mine interaction (hold left mouse to progressively break a voxel),
+use `sim::RemovalAccumulator` from `src/simulation/RemovalAccumulator.h`:
+
+```cpp
+#include "simulation/RemovalAccumulator.h"
+
+sim::RemovalAccumulator remover;
+
+// Each frame while the remove action is held:
+if (hit.hit) {
+    float hardness = world.getVoxel(
+        chunkmath::voxelCenter(hit.voxel, world.voxelSizeM())
+    ).material.hardness;
+
+    if (remover.accrue(hit.voxel, hardness, kToolPower, dt)) {
+        // The voxel broke -- clear it
+        WorldCoord center = chunkmath::voxelCenter(hit.voxel, world.voxelSizeM());
+        Voxel empty = Voxel::empty();
+        ctx->apply_edit(ctx, center, &empty);
+        remover.reset();
+    }
+
+    // Visual feedback
+    float progress = remover.progress();   // [0, 1]
+    renderer.drawVoxelHighlight(
+        chunkmath::voxelCenter(hit.voxel, world.voxelSizeM()),
+        static_cast<float>(world.voxelSizeM()),
+        0xff00ffff,
+        progress
+    );
+} else {
+    remover.reset();
+}
+```
+
+The accumulator is property-driven: it reads `hardness` from the target voxel's
+`MaterialProperties`, never a material ID. An indestructible target
+(`hardness < 0`) or a powerless tool (`power <= 0`) never accrues progress.
+
+When the targeted voxel changes, the accumulator automatically resets progress
+to zero.
+
+---
+
+## 8. Mining laser visualization
+
+Combine the raycast with the per-frame `drawVoxel` API to render a visible beam
+from the player to the targeted voxel.
+
+### The exercise
+
+Walk the ray from the camera origin to `hit.distance` in small steps, calling
+`drawVoxel` at each interval:
+
+```cpp
+if (hit.hit) {
+    double stepSize = 0.5;   // meters between beam segments
+    for (double d = 0.0; d < hit.distance; d += stepSize) {
+        WorldCoord stepPos(camPos.value + lookDir * d);
+        renderer.drawVoxel(stepPos, 0xff0000ff);   // ABGR red beam
+    }
+}
+```
+
+### Key points
+
+- **Per-frame submission:** `drawVoxel` is immediate-mode. The beam is transient
+  -- it is not placed in the world grid and vanishes if you stop submitting it.
+  This is the same API used to render player markers in multiplayer
+  ([Tutorial 11](11-multiplayer.md)).
+
+- **Performance:** `drawVoxel` submits one draw call per invocation. A very long
+  beam with tiny steps costs many draw calls. Recommend a step size of 0.5 to
+  1.0 meters. For a beam reaching 8 m at 0.5 m steps, that is 16 draw calls per
+  frame -- negligible.
+
+- **Color:** the `abgr` parameter is packed ABGR (`0xAABBGGRR`). `0xff0000ff`
+  is opaque red. Use `0xff00ff00` for green, `0xffffff00` for cyan, etc.
+
+### Extending the beam
+
+For a tractor-beam or scanning effect, vary the color along the ray:
+
+```cpp
+for (double d = 0.0; d < hit.distance; d += stepSize) {
+    float t = static_cast<float>(d / hit.distance);
+    uint8_t r = static_cast<uint8_t>(255 * (1.0f - t));
+    uint8_t b = static_cast<uint8_t>(255 * t);
+    uint32_t color = 0xff000000 | (b << 16) | r;   // red-to-blue gradient
+    WorldCoord stepPos(camPos.value + lookDir * d);
+    renderer.drawVoxel(stepPos, color);
+}
+```
+
+---
+
+## How to verify
+
+Build and run the build/break demo:
+
+```bash
+cmake -B build && cmake --build build
+./build/04-build-break-persist
+```
+
+In this demo:
+
+- **Left-click** removes the targeted voxel (with held-to-mine feedback if
+  the demo uses `RemovalAccumulator`).
+- **Right-click** places a voxel on the adjacent face.
+- A wireframe highlight shows which voxel you are aiming at.
+- Press **G** to toggle between fly-camera and walk-mode.
+- Edits persist across sessions (saved to a chunk file).
+
+Verify that:
+1. The highlight tracks the voxel under your crosshair.
+2. Removing a voxel clears it and remeshes the chunk.
+3. Placing a voxel fills the adjacent cell.
+4. Walking mode collides with solid voxels (you cannot walk through them).
+
+---
+
+## Key references
+
+| What | Where |
+|------|-------|
+| Raycast API and RayHit struct | `src/world/VoxelRaycast.h` |
+| AABB collision (moveAABB, MoveResult) | `src/world/VoxelCollision.h` |
+| RemovalAccumulator (held-to-mine) | `src/simulation/RemovalAccumulator.h` |
+| drawVoxel (immediate-mode voxel) | [`include/renderer/Renderer.h`](../../include/renderer/Renderer.h) |
+| drawVoxelHighlight (targeting outline) | `src/renderer/BgfxRenderer.h` |
+| apply_edit (plugin edit choke point) | [`include/plugin_api.h`](../../include/plugin_api.h) |
+| Camera position and rotation | [`include/renderer/Renderer.h`](../../include/renderer/Renderer.h) (`setCameraPosition`, `setCameraRotation`) |
+| Build/break demo | `demos/04-build-break-persist/main.cpp` |
+| Architecture: floating-origin camera | [`docs/architecture.md`](../architecture.md) section 9 |

--- a/docs/tutorials/09-player-mechanics.md
+++ b/docs/tutorials/09-player-mechanics.md
@@ -1,0 +1,484 @@
+# Tutorial 09: Player Mechanics
+
+Wire up first-person walk/mine/build gameplay with a full game HUD, using the
+kinematic-body plugin for physics, input plugins for device-agnostic controls,
+and the cell-grid overlay API for heads-up display elements.
+
+---
+
+## Prerequisites
+
+- The engine builds and runs successfully (see
+  [Tutorial 01](01-hello-voxel.md))
+- Familiarity with the plugin system ([Tutorial 02](02-your-first-plugin.md))
+- Understanding of raycasting and world edits
+  ([Tutorial 08](08-camera-raycasting-interaction.md))
+- A C++17 compiler
+
+---
+
+## 1. The kinematic-body plugin
+
+The `kinematic-body` plugin provides a body registry with gravity, jumping,
+and sweep-and-resolve AABB collision against the voxel world. It is a
+standalone plugin under `plugins/kinematic-body/` -- load it like any other
+plugin.
+
+### Creating a body
+
+Every moving entity in your game is a **body**, identified by a `BodyId`
+(a `uint32_t`, with `kInvalidBody = 0` as the null sentinel). You create
+one by filling out a `BodyDesc`:
+
+```cpp
+#include "kinematic_body.h"
+
+kinbody::BodyDesc desc;
+desc.center = WorldCoord(0.5, 27.0, 0.5);
+desc.half_x = 0.3;           // AABB half-extents
+desc.half_y = 0.9;
+desc.half_z = 0.3;
+desc.eye_offset = 0.7;       // camera height above center
+desc.walk_speed = 8.0;       // m/s
+desc.gravity_accel = 25.0;   // m/s^2
+desc.jump_speed = 9.0;       // m/s
+desc.gravity_dir_x = 0.0;
+desc.gravity_dir_y = -1.0;
+desc.gravity_dir_z = 0.0;
+
+kinbody::BodyId player = kinbody::api().create_body(&desc);
+```
+
+The `BodyDesc` struct captures everything about a body's shape and movement
+tuning:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `center` | `WorldCoord` | -- | Initial spawn position |
+| `half_x`, `half_y`, `half_z` | `double` | 0.3, 0.9, 0.3 | AABB half-extents |
+| `eye_offset` | `double` | 0.7 | Camera height above center |
+| `walk_speed` | `double` | 8.0 | Movement speed in m/s |
+| `gravity_accel` | `double` | 25.0 | Gravity acceleration in m/s^2 |
+| `jump_speed` | `double` | 9.0 | Initial upward velocity on jump |
+| `gravity_dir_*` | `double` | (0, -1, 0) | Gravity direction vector |
+
+### Per-frame input
+
+Each frame you tell the body what the player wants to do via `BodyInput`:
+
+```cpp
+kinbody::BodyInput in{};
+in.wish_x = forward * sin(yaw) + strafe * cos(yaw);
+in.wish_z = forward * cos(yaw) - strafe * sin(yaw);
+in.jump = jumpPressed;
+
+kinbody::api().set_input(player, &in);
+```
+
+The `wish_*` fields are a world-space wish direction (not velocity). The
+plugin clamps and scales them by `walk_speed` internally.
+
+### Reading state after the step
+
+After the engine ticks, read back the resolved state:
+
+```cpp
+const kinbody::BodyState* st = kinbody::api().get_state(player);
+
+WorldCoord eyePos(st->center.value + glm::dvec3(0, desc.eye_offset, 0));
+bool onGround = st->grounded;
+```
+
+The `BodyState` struct contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `center` | `WorldCoord` | Post-collision position |
+| `vel_x`, `vel_y`, `vel_z` | `double` | Current velocity |
+| `grounded` | `bool` | True if resting on a surface |
+| `hit_x`, `hit_y`, `hit_z` | `bool` | Axis-aligned collision flags |
+
+### Other body operations
+
+```cpp
+// Teleport / respawn:
+kinbody::api().set_position(player, WorldCoord(0.5, 50.0, 0.5));
+
+// Change gravity per body (e.g. low-gravity zone):
+kinbody::api().set_gravity(player, 0.0, -1.0, 0.0, 10.0);
+
+// Destroy when the player disconnects:
+kinbody::api().destroy_body(player);
+
+// Query how many bodies exist:
+uint32_t count = kinbody::api().body_count();
+```
+
+---
+
+## 2. The register_on_tick hook
+
+The kinematic-body plugin steps all bodies during the engine tick. Internally
+it registers a tick callback:
+
+```cpp
+ctx->register_on_tick(ctx, tick, nullptr);
+```
+
+Inside its tick function the plugin calls `ctx->move_aabb` for each body:
+
+```cpp
+BodyMoveResult result = ctx->move_aabb(ctx,
+    center, half_x, half_y, half_z,
+    dx, dy, dz,
+    grav_x, grav_y, grav_z);
+```
+
+The `BodyMoveResult` contains `position`, `grounded`, `hitX`, `hitY`, and
+`hitZ` -- the sweep-and-resolve collision output. You do not need to call
+`move_aabb` directly; the kinematic-body plugin handles it. But understanding
+the flow matters when debugging collision edge cases.
+
+If you need your own per-frame logic (AI, animation), register an additional
+tick callback:
+
+```cpp
+ctx->register_on_tick(ctx, my_tick_fn, my_user_data);
+```
+
+---
+
+## 3. Input plugins
+
+The engine ships two input plugins that wrap GLFW into a device-agnostic
+query API.
+
+### Keyboard and mouse
+
+```cpp
+#include "keyboard-mouse/plugin.h"  // or via plugin_api.h
+
+kbinput::api().set_source(&kbSrc);
+
+// Bind axes (negative key, positive key):
+kbinput::api().bind_axis("forward", GLFW_KEY_S, GLFW_KEY_W);
+kbinput::api().bind_axis("strafe",  GLFW_KEY_A, GLFW_KEY_D);
+
+// Bind discrete keys:
+kbinput::api().bind_key("jump", GLFW_KEY_SPACE);
+
+// Bind mouse buttons:
+kbinput::api().bind_mouse_button("mine",  GLFW_MOUSE_BUTTON_LEFT);
+kbinput::api().bind_mouse_button("place", GLFW_MOUSE_BUTTON_RIGHT);
+
+// Sensitivity:
+kbinput::api().set_mouse_sensitivity(0.0022);
+```
+
+Query each frame:
+
+```cpp
+float fwd   = kbinput::api().axis("forward");   // -1.0 to 1.0
+bool  mining = kbinput::api().held("mine");      // held this frame
+bool  jumped = kbinput::api().pressed("jump");   // pressed this frame (edge)
+
+double dx, dy;
+kbinput::api().mouse_delta(&dx, &dy);            // raw mouse delta
+```
+
+### Gamepad
+
+```cpp
+gpinput::api().set_source(&gpSrc);
+
+gpinput::api().bind_button("jump", GLFW_GAMEPAD_BUTTON_A);
+gpinput::api().bind_trigger("mine", gpinput::AxisRightTrigger);
+
+float lx, ly;
+gpinput::api().stick(gpinput::StickLeft, &lx, &ly);  // left stick axes
+```
+
+### Auto device switching
+
+Track which device last produced input and set `activeDevice` accordingly.
+A simple pattern:
+
+```cpp
+enum class Device { Keyboard, Gamepad };
+Device activeDevice = Device::Keyboard;
+
+// Each frame:
+if (kbinput::api().any_activity())
+    activeDevice = Device::Keyboard;
+if (gpinput::api().any_activity())
+    activeDevice = Device::Gamepad;
+```
+
+Display the active device on the HUD status line (section 7) so the player
+knows which control scheme is live.
+
+---
+
+## 4. Hardness-gated mining with visual feedback
+
+Mining is not instant -- every material has a `hardness` value (see
+[Tutorial 03](03-materials-and-properties.md)), and the player accumulates
+removal progress over time.
+
+```cpp
+sim::RemovalAccumulator remover;
+
+// Each frame, when aiming at a voxel and holding the mine button:
+if (hit.hit && mining) {
+    if (remover.accrue(hit.voxel, target.material.hardness, kToolPower, dt)) {
+        // Voxel fully mined -- break it:
+        Voxel empty = Voxel::empty();
+        ctx->apply_edit(ctx, hit.voxel, &empty);
+        remover.reset();
+    }
+}
+
+// Visual feedback: the progress ramp (0.0 to 1.0):
+float progress = remover.progress();
+renderer.drawVoxelHighlight(hit.voxel, voxelSize, highlightColor, progress);
+```
+
+When the player looks away from the target voxel, call `remover.reset()` to
+restart the accumulation. The `drawVoxelHighlight` progress parameter drives
+the visual crack/ramp effect on the targeted block (see
+[Tutorial 08](08-camera-raycasting-interaction.md) for the highlight API).
+
+---
+
+## 5. The on_voxel_modified callback
+
+React to any block change in the world -- whether from mining, placing, or
+network replication:
+
+```cpp
+ctx->register_on_voxel_modified(ctx, [](WorldCoord pos, const Voxel* old_v,
+    const Voxel* new_v, PlayerId source, void* ud) {
+    // old_v: what was there before
+    // new_v: what is there now
+    // source: which player made the change
+
+    if (new_v->isEmpty()) {
+        // A voxel was removed -- update inventory, play break sound
+    } else if (old_v->isEmpty()) {
+        // A voxel was placed
+    }
+}, userData);
+```
+
+This is the same callback the `material-audio` plugin uses to trigger
+break/place sounds (see [Tutorial 10](10-audio-and-sound.md)). It fires for
+all edit sources -- local player, remote peers, and plugin-driven edits.
+
+---
+
+## 6. HUD integration via cell-grid overlay API
+
+The renderer exposes a text-mode overlay grid for HUD elements. Each cell
+is a glyph + attribute byte, similar to a classic text-mode framebuffer.
+
+### Setup
+
+Call `hudClear()` once per frame before drawing any HUD elements:
+
+```cpp
+renderer.hudClear();
+```
+
+Query grid dimensions for layout calculations:
+
+```cpp
+int cols = renderer.hudCols();
+int rows = renderer.hudRows();
+```
+
+### Text
+
+```cpp
+renderer.hudText(col, row, hud::attr(hud::White), "HP");
+```
+
+### Filled rectangles (health bar)
+
+```cpp
+int barWidth = 20;
+int filled = static_cast<int>(hp * barWidth);
+
+// Green filled portion:
+renderer.hudFill(4, 1, filled, 1, hud::attr(hud::Black, hud::Green));
+// Gray empty portion:
+renderer.hudFill(4 + filled, 1, barWidth - filled, 1,
+                 hud::attr(hud::Black, hud::DarkGray));
+```
+
+### Blit pre-built cell buffers (minimap)
+
+For complex HUD elements like a minimap, build a cell buffer offline and blit
+it in one call:
+
+```cpp
+renderer.hudCells(col, row, width, height, minimapData.data());
+```
+
+The data format is 2 bytes per cell: glyph + attribute.
+
+### Color system
+
+The `hud::Color` enum provides 16 colors:
+
+> Black, Blue, Green, Cyan, Red, Magenta, Brown, LightGray, DarkGray,
+> LightBlue, LightGreen, LightCyan, LightRed, LightMagenta, Yellow, White
+
+Pack foreground and background into a single attribute byte:
+
+```cpp
+uint8_t attr = hud::attr(foreground, background);
+// Internally: (bg << 4) | (fg & 0x0f)
+```
+
+### Inventory hotbar
+
+Render material slots along the bottom of the screen:
+
+```cpp
+for (int i = 0; i < 5; ++i) {
+    int col = cols / 2 - 5 + i * 2;
+    int row = rows - 2;
+    uint8_t a = (i == selectedSlot)
+        ? hud::attr(hud::White, hud::LightBlue)
+        : hud::attr(hud::LightGray, hud::Black);
+    char label = '1' + i;
+    renderer.hudText(col, row, a, std::string(1, label));
+}
+```
+
+### Status line
+
+Use the bottom row for coordinates, active device, and FPS:
+
+```cpp
+char statusBuf[128];
+snprintf(statusBuf, sizeof(statusBuf),
+         "X:%.0f Y:%.0f Z:%.0f | %s | %.0f FPS",
+         st->center.value.x, st->center.value.y, st->center.value.z,
+         activeDevice == Device::Keyboard ? "KB/Mouse" : "Gamepad",
+         1.0 / dt);
+renderer.hudText(0, rows - 1, hud::attr(hud::Yellow), statusBuf);
+```
+
+---
+
+## 7. Putting it all together
+
+A condensed game loop showing all the pieces wired together:
+
+```cpp
+kinbody::BodyDesc desc{};
+desc.center = WorldCoord(0.5, 27.0, 0.5);
+desc.eye_offset = 0.7;
+kinbody::BodyId player = kinbody::api().create_body(&desc);
+
+sim::RemovalAccumulator remover;
+
+while (!window.shouldClose()) {
+    double dt = timer.delta();
+    window.pollEvents();
+
+    // 1. Gather input
+    float fwd    = kbinput::api().axis("forward");
+    float strafe = kbinput::api().axis("strafe");
+    bool  jump   = kbinput::api().pressed("jump");
+    bool  mining = kbinput::api().held("mine");
+
+    double mdx, mdy;
+    kbinput::api().mouse_delta(&mdx, &mdy);
+    yaw   += mdx;
+    pitch  = glm::clamp(pitch - mdy, -1.55, 1.55);
+
+    // 2. Feed kinematic body
+    kinbody::BodyInput in{};
+    in.wish_x = fwd * sin(yaw) + strafe * cos(yaw);
+    in.wish_z = fwd * cos(yaw) - strafe * sin(yaw);
+    in.jump   = jump;
+    kinbody::api().set_input(player, &in);
+
+    // 3. Step the engine (ticks all bodies)
+    engine.update(dt);
+
+    // 4. Read back state
+    const kinbody::BodyState* st = kinbody::api().get_state(player);
+    WorldCoord eye(st->center.value + glm::dvec3(0, desc.eye_offset, 0));
+
+    // 5. Raycast for interaction
+    glm::dvec3 dir(cos(pitch)*sin(yaw), sin(pitch), cos(pitch)*cos(yaw));
+    auto hit = voxelcast::raycast(world, eye, dir, 8.0);
+
+    // 6. Mining
+    if (hit.hit && mining) {
+        Voxel target = world.getVoxel(hit.voxel);
+        if (remover.accrue(hit.voxel, target.material.hardness, kToolPower, dt)) {
+            Voxel empty = Voxel::empty();
+            ctx->apply_edit(ctx, hit.voxel, &empty);
+            remover.reset();
+        }
+        renderer.drawVoxelHighlight(hit.voxel, 1.0, 0xff00ffff, remover.progress());
+    } else {
+        remover.reset();
+    }
+
+    // 7. HUD
+    renderer.hudClear();
+    // ... health bar, hotbar, status line (see section 6)
+
+    // 8. Render
+    renderer.setCameraPosition(eye);
+    renderer.setCameraRotation(pitch, yaw, 0.0f);
+    renderer.renderWorld(world);
+    renderer.render();
+}
+```
+
+---
+
+## How to verify
+
+Build and run the HUD-and-controls demo:
+
+```bash
+cmake -B build && cmake --build build
+./build/18-hud-and-controls
+```
+
+You should see:
+
+- First-person movement with WASD, mouse look, and space to jump.
+- Gravity pulls the player down; jumping launches upward.
+- Left-click mines voxels with a progress indicator; harder materials take
+  longer.
+- A health bar, inventory hotbar, coordinate readout, and FPS counter are
+  drawn on screen via the cell-grid HUD.
+- If a gamepad is connected, grabbing it switches the active device
+  indicator automatically.
+
+---
+
+## Key references
+
+| What | Where |
+|------|-------|
+| Kinematic body API | `plugins/kinematic-body/kinematic_body.h` |
+| Kinematic body implementation | `plugins/kinematic-body/plugin.cpp` |
+| Keyboard-mouse input plugin | `plugins/keyboard-mouse/plugin.cpp` |
+| Gamepad input plugin | `plugins/gamepad/plugin.cpp` |
+| HUD overlay API | `src/renderer/BgfxRenderer.h` |
+| Removal accumulator | `include/plugin_api.h` (`RemovalAccumulator`) |
+| Voxel highlight | `include/renderer/Renderer.h` (`drawVoxelHighlight`) |
+| Demo source | `demos/18-hud-and-controls/main.cpp` |
+| Material properties (hardness) | [Tutorial 03](03-materials-and-properties.md) |
+| Raycasting and edits | [Tutorial 08](08-camera-raycasting-interaction.md) |
+| Audio feedback on edits | [Tutorial 10](10-audio-and-sound.md) |
+| Architecture overview | [`docs/architecture.md`](../architecture.md) |

--- a/docs/tutorials/10-audio-and-sound.md
+++ b/docs/tutorials/10-audio-and-sound.md
@@ -1,0 +1,321 @@
+# Tutorial 10: Audio and Sound
+
+Add material-reactive positional audio to your game using the AudioManager
+subsystem, sound registration, material-sound bindings, and persistent
+emitters.
+
+---
+
+## Prerequisites
+
+- The engine builds and runs successfully (see
+  [Tutorial 01](01-hello-voxel.md))
+- Familiarity with the plugin system ([Tutorial 02](02-your-first-plugin.md))
+- Understanding of materials and palette indices
+  ([Tutorial 03](03-materials-and-properties.md))
+- Knowledge of the `on_voxel_modified` callback
+  ([Tutorial 09](09-player-mechanics.md))
+
+---
+
+## 1. Audio subsystem setup
+
+The audio subsystem is built on a `MiniaudioBackend` and managed through the
+`AudioManager`. Wire it up during engine initialization:
+
+```cpp
+audio::MiniaudioBackend backend(/*useNullDevice=*/false);
+audio::AudioManager audioManager(&backend, pluginManager);
+pluginManager.setAudioManager(&audioManager);
+audioManager.preloadSounds();
+```
+
+Pass `true` to `useNullDevice` for headless testing or CI environments where
+no audio device is available.
+
+### Listener placement
+
+Every frame, update the listener position and orientation so the audio engine
+can compute spatialization:
+
+```cpp
+glm::vec3 fwd{cos(pitch) * sin(yaw), sin(pitch), cos(pitch) * cos(yaw)};
+audioManager.setListener(camPos, fwd, glm::vec3(0, 1, 0));
+```
+
+The three arguments are: world position, forward direction, and up vector.
+
+### Audio tick
+
+Call `update()` once per frame to pump the audio engine:
+
+```cpp
+audioManager.update();
+```
+
+---
+
+## 2. Registering sound assets
+
+Sounds are registered by name with a `SoundParams` struct that controls
+volume and spatial attenuation:
+
+```cpp
+SoundParams blockParams{};
+blockParams.volume       = 0.8f;
+blockParams.attenuation  = AttenuationModel::Inverse;
+blockParams.min_distance = 1.0f;
+blockParams.max_distance = 40.0f;
+blockParams.rolloff      = 1.0f;
+blockParams.doppler      = 0.0f;  // 0 = off
+
+ctx->register_sound(ctx, "stone_break", "assets/audio/stone_break.wav", blockParams);
+```
+
+### SoundParams fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `volume` | `float` | 1.0 | Playback volume multiplier |
+| `attenuation` | `AttenuationModel` | `Inverse` | Distance falloff curve |
+| `min_distance` | `float` | 1.0 | Distance at which attenuation begins |
+| `max_distance` | `float` | 100.0 | Distance beyond which the sound is silent |
+| `rolloff` | `float` | 1.0 | Steepness of the attenuation curve |
+| `doppler` | `float` | 0.0 | Doppler factor (0 disables) |
+
+### AttenuationModel enum
+
+| Value | Behavior |
+|-------|----------|
+| `Inverse` | 1/distance falloff (realistic for most effects) |
+| `Linear` | Linear ramp from min to max distance |
+| `Exponential` | Steep exponential falloff |
+| `None` | No distance attenuation (UI sounds, music) |
+
+### Asset path resolution
+
+Sound files are loaded from `assets/audio/` relative to the working
+directory. The engine supports WAV format. Organize your sounds by category:
+
+```
+assets/audio/
+  stone_break.wav
+  stone_place.wav
+  stone_step.wav
+  dirt_break.wav
+  dirt_place.wav
+  dirt_step.wav
+  ambient_wind.wav
+```
+
+---
+
+## 3. Material-sound bindings
+
+Rather than manually choosing a sound for every voxel interaction, bind
+sounds to materials by event type. The engine resolves the correct sound at
+play time based on the voxel's `palette_index`:
+
+```cpp
+ctx->register_material_sound(ctx, "stone", AudioEvent::Break,    "stone_break");
+ctx->register_material_sound(ctx, "stone", AudioEvent::Place,    "stone_place");
+ctx->register_material_sound(ctx, "stone", AudioEvent::Footstep, "stone_step");
+```
+
+### AudioEvent enum
+
+| Value | When it fires |
+|-------|---------------|
+| `Footstep` | Player walks on this material |
+| `Break` | A voxel of this material is removed |
+| `Place` | A voxel of this material is placed |
+
+This binding system means adding a new material automatically gets audio
+support -- just register its sounds and bindings in your plugin's init.
+
+---
+
+## 4. Playing sounds
+
+### Via material binding (preferred)
+
+When a game event occurs, play the sound associated with the material:
+
+```cpp
+ctx->play_material_sound(ctx, AudioEvent::Break,
+                         voxel.material.palette_index, position);
+```
+
+The engine looks up the material name from `palette_index`, finds the
+registered sound for the given `AudioEvent`, and plays it at `position` with
+the `SoundParams` it was registered with.
+
+### Direct sound by ID
+
+For non-material sounds (UI feedback, ambient effects), play by sound name:
+
+```cpp
+SoundParams uiParams{};
+uiParams.attenuation = AttenuationModel::None;  // no distance falloff
+ctx->play_sound(ctx, "ui_click", position, uiParams);
+```
+
+---
+
+## 5. Persistent emitters
+
+For looping or long-running sounds (ambient wind, machinery, water flow),
+create a persistent emitter:
+
+```cpp
+EmitterParams ep{};
+ep.sound.volume       = 0.5f;
+ep.sound.min_distance = 8.0f;
+ep.sound.max_distance = 80.0f;
+ep.loop               = true;
+
+AudioEmitterId emitter = ctx->create_emitter(ctx, "ambient_wind", position, ep);
+```
+
+The return value is an `AudioEmitterId`. A failed creation returns
+`kInvalidEmitterId` (0).
+
+### Updating and stopping
+
+Move the emitter each frame if its source is dynamic:
+
+```cpp
+ctx->set_emitter_position(ctx, emitter, newPosition);
+```
+
+When the sound should stop:
+
+```cpp
+ctx->stop_emitter(ctx, emitter);
+```
+
+`stop_emitter` both stops playback and destroys the emitter handle.
+
+### Owner-tracked resources
+
+All sounds and emitters registered by a plugin are automatically torn down
+when the plugin is unloaded. You do not need to manually clean up in a
+shutdown hook -- the engine tracks ownership by plugin ID.
+
+---
+
+## 6. The material-audio plugin
+
+The `material-audio` plugin (`plugins/material-audio/plugin.cpp`) is a
+reference implementation that wires break/place sounds to the
+`on_voxel_modified` callback:
+
+```cpp
+// In plugin init:
+static PluginContext* g_ctx = nullptr;
+g_ctx = ctx;
+
+ctx->register_on_voxel_modified(ctx, [](WorldCoord pos, const Voxel* old_v,
+    const Voxel* new_v, PlayerId source, void* ud) {
+
+    if (new_v->isEmpty()) {
+        // Voxel was broken
+        g_ctx->play_material_sound(g_ctx, AudioEvent::Break,
+                                   old_v->material.palette_index, pos);
+    } else if (old_v->isEmpty()) {
+        // Voxel was placed
+        g_ctx->play_material_sound(g_ctx, AudioEvent::Place,
+                                   new_v->material.palette_index, pos);
+    }
+}, nullptr);
+```
+
+The plugin stores `g_ctx` at init time so the callback closure can call back
+into the plugin API. It checks `Voxel::isEmpty()` to distinguish break
+(old was solid, new is empty) from place (old was empty, new is solid).
+
+---
+
+## 7. Footstep sounds
+
+Footsteps require knowing which material the player is standing on. The
+pattern from demo 12:
+
+```cpp
+const double kStrideLength = 2.5;  // meters per footstep
+double strideAccum = 0.0;
+
+// Each frame, while grounded and moving:
+if (grounded && speed > 0.1) {
+    strideAccum += speed * dt;
+    if (strideAccum >= kStrideLength) {
+        strideAccum -= kStrideLength;
+
+        // Sample the voxel under the player's feet:
+        WorldCoord feetPos(st->center.value - glm::dvec3(0, desc.half_y, 0));
+        Voxel ground = world.getVoxel(WorldCoord(feetPos));
+
+        audioManager.playMaterialSound(AudioEvent::Footstep,
+                                       ground.material.palette_index,
+                                       WorldCoord(feetPos));
+    }
+}
+```
+
+The stride accumulator ensures footsteps fire at a natural walking cadence
+regardless of frame rate. Adjust `kStrideLength` to taste -- shorter values
+give a faster-paced sound, longer values a more relaxed gait.
+
+---
+
+## 8. Teardown order
+
+When shutting down, follow this order to avoid dangling references:
+
+```cpp
+// 1. Stop all emitters (automatic if plugins are unloaded first)
+// 2. Disconnect the audio manager from the plugin manager:
+pluginManager.setAudioManager(nullptr);
+// 3. Destroy audio objects (AudioManager destructor)
+```
+
+The `AudioManager` destructor releases all backend resources. If plugins are
+unloaded before the audio manager is destroyed, their emitters are already
+stopped via owner tracking.
+
+---
+
+## How to verify
+
+Build and run the soundscape demo:
+
+```bash
+cmake -B build && cmake --build build
+./build/12-soundscape
+```
+
+You should hear:
+
+- **Footsteps** that change sound based on the ground material (stone vs.
+  dirt vs. grass) as you walk.
+- **Break sounds** when you mine a voxel -- stone cracks, dirt thuds.
+- **Place sounds** when you build.
+- **Spatial audio**: sounds are louder when close, quieter when far away,
+  and panned to the correct direction.
+- **Ambient emitters**: a looping wind sound in the background, correctly
+  spatialized as you move around.
+
+---
+
+## Key references
+
+| What | Where |
+|------|-------|
+| Sound registration API | `include/plugin_api.h` (`SoundParams`, `register_sound`) |
+| Material-sound bindings | `include/plugin_api.h` (`register_material_sound`, `AudioEvent`) |
+| Emitter API | `include/plugin_api.h` (`EmitterParams`, `create_emitter`, `stop_emitter`) |
+| Material-audio plugin | `plugins/material-audio/plugin.cpp` |
+| Demo source | `demos/12-soundscape/main.cpp` |
+| Material properties | [Tutorial 03](03-materials-and-properties.md) |
+| Voxel modification callback | [Tutorial 09](09-player-mechanics.md) |
+| Architecture overview | [`docs/architecture.md`](../architecture.md) |

--- a/docs/tutorials/11-multiplayer.md
+++ b/docs/tutorials/11-multiplayer.md
@@ -1,0 +1,457 @@
+# Tutorial 11: Multiplayer
+
+Add multiplayer to your game with edit replication, custom messaging, player
+lifecycle hooks, and visible player markers using the host-as-authority
+networking model.
+
+---
+
+## Prerequisites
+
+- The engine builds and runs successfully (see
+  [Tutorial 01](01-hello-voxel.md))
+- Familiarity with the plugin system ([Tutorial 02](02-your-first-plugin.md))
+- Understanding of world edits via `apply_edit`
+  ([Tutorial 08](08-camera-raycasting-interaction.md))
+- Knowledge of the `on_voxel_modified` callback
+  ([Tutorial 09](09-player-mechanics.md))
+
+---
+
+## 1. The host-as-authority P2P model
+
+VoxelEngine uses a host-as-authority peer-to-peer model. One instance acts
+as both the authoritative server and a local client (the "host peer").
+Other instances connect as pure clients. There is no dedicated server
+binary -- the host is a regular game instance that also validates edits.
+
+### Setting up the NetworkManager
+
+```cpp
+net::NetworkManager nm;
+nm.init(world, pluginManager);
+```
+
+### Starting as host
+
+```cpp
+nm.setWorldSave(&save);
+nm.setWorldSeed(kWorldSeed);
+nm.setLayerConfig(&layerConfig);
+nm.startHostPeer(27777);  // port; runs authority + local client
+```
+
+The host owns the canonical world state. It validates all incoming edits,
+commits them, and broadcasts the results to connected peers.
+
+### Starting as client
+
+```cpp
+nm.startClient("localhost", 27777);
+```
+
+The client receives the world seed and layer config from the host, then
+streams chunk data as needed. Call `nm.joinComplete()` to check when the
+initial world state has synced:
+
+```cpp
+if (nm.joinComplete()) {
+    // World is loaded, safe to start gameplay
+}
+```
+
+### Wiring into the engine
+
+```cpp
+engine.setNetworkManager(&nm);
+```
+
+Per-tick update:
+
+```cpp
+nm.update(dt);
+```
+
+---
+
+## 2. Edit replication
+
+All world edits flow through a single choke point -- `applyEdit` on the
+NetworkManager (or `apply_edit` via the plugin context). This ensures every
+edit is validated, committed, and replicated consistently.
+
+```cpp
+// From game code:
+nm.applyEdit(kLocalPlayer, position, newVoxel);
+
+// From plugin code:
+ctx->apply_edit(ctx, position, &voxel);
+```
+
+The replication flow:
+
+1. **Client** calls `applyEdit` -- the edit is forwarded to the host.
+2. **Host** validates the edit (via authority policy, see section 3).
+3. **Host** commits the edit to the world.
+4. **Host** broadcasts the committed edit to all peers (filtered by interest,
+   see section 5).
+5. **Each peer** applies the edit locally and fires `on_voxel_modified`.
+
+This happens within one round-trip. The client does not apply the edit
+locally until it receives confirmation from the host (authoritative model).
+
+---
+
+## 3. Custom authority policy
+
+The host can validate edit intents before they are committed. Register an
+authority policy to implement access control, protected regions, or
+game-rule enforcement:
+
+```cpp
+ctx->register_authority_policy(ctx, [](PlayerId peer, WorldCoord pos,
+    const Voxel* proposed, void* ud) -> bool {
+    // Return true to allow the edit, false to reject it
+
+    // Example: protect a spawn region
+    if (glm::length(pos.value - glm::dvec3(0, 0, 0)) < 10.0)
+        return false;  // reject edits near spawn
+
+    return true;
+}, nullptr);
+```
+
+The policy runs on the host only. If it returns `false`, the edit is silently
+dropped -- the requesting client receives no confirmation and the world
+remains unchanged.
+
+---
+
+## 4. Edit conflict resolution
+
+For more nuanced control than accept/reject, register an edit-received
+handler that can transform edits:
+
+```cpp
+ctx->register_on_edit_received(ctx, [](PlayerId proposer, WorldCoord pos,
+    const Voxel* proposed, Voxel* out_voxel, void* ud) -> EditResolution {
+
+    // EditResolution::Apply    -- accept the edit as-is
+    // EditResolution::Discard  -- reject the edit
+    // EditResolution::Transform -- commit *out_voxel instead of *proposed
+
+    // Example: downgrade a high-density material for non-admin players
+    if (proposed->material.density > 5000.0f && proposer != kAdminPlayer) {
+        *out_voxel = *proposed;
+        out_voxel->material.density = 2600.0f;
+        return EditResolution::Transform;
+    }
+
+    return EditResolution::Apply;
+}, nullptr);
+```
+
+The three resolution modes:
+
+| Resolution | Effect |
+|------------|--------|
+| `Apply` | Commit `proposed` as-is |
+| `Discard` | Drop the edit entirely |
+| `Transform` | Commit `*out_voxel` (your modified version) instead |
+
+---
+
+## 5. Interest filtering
+
+Not every peer needs every edit. Interest filtering controls which edits
+reach which clients, saving bandwidth in large worlds.
+
+### Built-in modes
+
+```cpp
+// Every edit goes to every peer (simple, high bandwidth):
+nm.setInterestMode(net::InterestMode::BroadcastAll);
+
+// Only send edits within streaming radius of each peer:
+nm.setInterestMode(net::InterestMode::StreamingRadius);
+```
+
+### Custom filter
+
+For game-specific rules (team visibility, fog of war, dimension separation):
+
+```cpp
+ctx->register_interest_filter(ctx, [](PlayerId target, WorldCoord editPos,
+    void* ud) -> bool {
+    // Return true if 'target' should receive the edit at 'editPos'
+
+    // Example: only send edits within 200m of the target player
+    WorldCoord targetPos = getPlayerPosition(target);
+    return glm::length(editPos.value - targetPos.value) < 200.0;
+}, nullptr);
+```
+
+The trade-off: `BroadcastAll` is simplest but scales poorly.
+`StreamingRadius` is a good default for open-world games. Custom filters
+give full control but require careful design to avoid desyncs (a player
+who walks into a region they were filtered out of needs a chunk re-sync).
+
+---
+
+## 6. Custom network messages
+
+Beyond edit replication, you can send arbitrary messages between peers using
+channel-based messaging.
+
+### MessageEnvelope
+
+```cpp
+struct MessageEnvelope {
+    const char* channel_id;           // e.g. "engine.chat"
+    PlayerId sender_id = 0;           // filled by the engine on receive
+    PlayerId target_player = 0;       // for targeted messages
+    MessageTarget target = MessageTarget::Broadcast;
+    MessageReliability reliability = MessageReliability::Reliable;
+    const void* payload;
+    size_t payload_size;
+};
+```
+
+### Sending a message
+
+```cpp
+std::string text = "Hello, world!";
+
+MessageEnvelope env{};
+env.channel_id  = "engine.chat";
+env.target      = MessageTarget::Broadcast;
+env.reliability = MessageReliability::Reliable;
+env.payload      = text.c_str();
+env.payload_size = text.size();
+
+ctx->send_network_message(ctx, &env);
+```
+
+For targeted messages, set `env.target = MessageTarget::Player` and fill in
+`env.target_player`.
+
+### Receiving messages
+
+Subscribe to a channel prefix to receive messages:
+
+```cpp
+ctx->register_on_network_message(ctx, "engine.chat",
+    [](const MessageEnvelope* env, void* ud) {
+        std::string msg(static_cast<const char*>(env->payload),
+                        env->payload_size);
+        // env->sender_id identifies who sent it
+        printf("[Player %u]: %s\n", env->sender_id, msg.c_str());
+    }, nullptr);
+```
+
+The prefix match means registering for `"engine."` would receive both
+`"engine.chat"` and `"engine.status"` messages. Use this for plugin
+namespacing.
+
+### The chat plugin as a worked example
+
+The `chat` plugin (`plugins/chat/plugin.cpp`) demonstrates the full message
+pattern:
+
+1. Registers a handler for `"engine.chat"` messages.
+2. Exposes a function to send chat text.
+3. On receive, formats and displays the message with the sender's player ID.
+
+Study it as a minimal reference for any custom messaging feature (trade
+requests, team commands, game events).
+
+---
+
+## 7. Player lifecycle hooks
+
+React to players joining and leaving the session:
+
+```cpp
+ctx->register_on_player_joined(ctx, [](PlayerId id, WorldCoord pos, void* ud) {
+    printf("Player %u joined at (%.0f, %.0f, %.0f)\n",
+           id, pos.value.x, pos.value.y, pos.value.z);
+    // Spawn their avatar, send welcome message, etc.
+}, nullptr);
+
+ctx->register_on_player_left(ctx, [](PlayerId id, void* ud) {
+    printf("Player %u left\n", id);
+    // Remove avatar, clean up resources
+}, nullptr);
+```
+
+These fire on the host for all peers, and on each client for remote peers.
+
+---
+
+## 8. Player voxel representation
+
+Remote players need a visible presence in the world. The engine does not
+impose an avatar model -- instead, use the immediate-mode `drawVoxel` API
+to render colored markers at each peer's position:
+
+```cpp
+const uint32_t kPlayerColors[] = {0xff0000ff, 0xff00ff00, 0xffff8800, 0xffff00ff};
+
+for (const auto& [playerId, pos] : nm.playerPositions()) {
+    renderer.drawVoxel(pos, kPlayerColors[playerId % 4]);
+}
+```
+
+### Key properties of drawVoxel markers
+
+- **Per-frame / immediate-mode**: the marker is submitted each frame and is
+  transient. It is never placed in the world grid.
+- **No cleanup needed**: when a peer disconnects, you simply stop drawing
+  their marker. There is nothing to remove from the world.
+- **No collision or physics**: `drawVoxel` is rendering-only. The marker
+  does not participate in collision detection or persistence.
+
+### Multi-voxel figures
+
+For a more readable player representation, use multiple `drawVoxel` calls
+per peer to build a small figure:
+
+```cpp
+for (const auto& [playerId, pos] : nm.playerPositions()) {
+    uint32_t color = kPlayerColors[playerId % 4];
+    // Body (1x1x1 at feet level):
+    renderer.drawVoxel(pos, color);
+    // Head (1x1x1 above body):
+    WorldCoord headPos(pos.value + glm::dvec3(0, 1, 0));
+    renderer.drawVoxel(headPos, color);
+}
+```
+
+### Position broadcasting
+
+Each frame, broadcast the local player's position so others can see it:
+
+```cpp
+nm.broadcastLocalPosition(camPos);
+```
+
+On the host, peer positions are tracked automatically:
+
+```cpp
+nm.updatePeerPosition(playerId, pos);
+```
+
+---
+
+## 9. NetworkManager queries
+
+The `NetworkManager` exposes several status queries for UI and diagnostics:
+
+| Method | Return | Description |
+|--------|--------|-------------|
+| `nm.role()` | `SessionRole` | `Offline`, `Server`, `Client`, or `HostPeer` |
+| `nm.isActive()` | `bool` | True if networking is running |
+| `nm.localPlayerId()` | `PlayerId` | This instance's player ID |
+| `nm.connectedPeerCount()` | `uint32_t` | Number of connected peers |
+| `nm.packetsReceived()` | `uint64_t` | Total packets received (diagnostics) |
+| `nm.rttMs(PlayerId)` | `float` | Smoothed round-trip time to a peer |
+| `nm.joinComplete()` | `bool` | Client: true when world state is synced |
+
+Use `rttMs` to display latency in the HUD (see
+[Tutorial 09](09-player-mechanics.md) for HUD integration). Use
+`connectedPeerCount` for player-count displays.
+
+---
+
+## 10. Putting it all together
+
+A condensed host setup showing all the pieces:
+
+```cpp
+net::NetworkManager nm;
+nm.init(world, pluginManager);
+engine.setNetworkManager(&nm);
+
+// Authority policy: protect spawn
+ctx->register_authority_policy(ctx, [](PlayerId peer, WorldCoord pos,
+    const Voxel* proposed, void* ud) -> bool {
+    return glm::length(pos.value) >= 10.0;  // reject edits near origin
+}, nullptr);
+
+// Player lifecycle
+ctx->register_on_player_joined(ctx, [](PlayerId id, WorldCoord pos, void* ud) {
+    printf("Player %u joined\n", id);
+}, nullptr);
+
+// Chat messaging
+ctx->register_on_network_message(ctx, "engine.chat",
+    [](const MessageEnvelope* env, void* ud) {
+        std::string msg(static_cast<const char*>(env->payload), env->payload_size);
+        printf("[%u]: %s\n", env->sender_id, msg.c_str());
+    }, nullptr);
+
+// Start hosting
+nm.startHostPeer(27777);
+
+while (!window.shouldClose()) {
+    nm.update(dt);
+    engine.update(dt);
+
+    // Broadcast our position
+    nm.broadcastLocalPosition(camPos);
+
+    // Draw remote players
+    for (const auto& [pid, pos] : nm.playerPositions())
+        renderer.drawVoxel(pos, kPlayerColors[pid % 4]);
+
+    // World edits go through the network manager:
+    if (placingVoxel)
+        nm.applyEdit(nm.localPlayerId(), targetPos, newVoxel);
+
+    renderer.renderWorld(world);
+    renderer.render();
+}
+```
+
+---
+
+## How to verify
+
+Build and run two instances of the shared-world demo:
+
+```bash
+cmake -B build && cmake --build build
+
+# Terminal 1 -- host:
+./build/11-shared-world --host
+
+# Terminal 2 -- client (same machine):
+./build/11-shared-world --join localhost
+```
+
+You should see:
+
+- Both windows show the same world.
+- Edits made in one window appear in the other within one round-trip.
+- Each player sees the other as a colored voxel marker that moves in
+  real-time.
+- The host's authority policy is enforced -- edits rejected by the policy
+  do not appear on any client.
+- If you close the client window, the host continues running and the
+  player marker disappears.
+
+---
+
+## Key references
+
+| What | Where |
+|------|-------|
+| NetworkManager API | `src/net/NetworkManager.h` |
+| Networking plugin hooks | `include/plugin_api.h` (authority, interest, messaging) |
+| Chat plugin (messaging example) | `plugins/chat/plugin.cpp` |
+| Server authority plugin | `plugins/server-authority/plugin.cpp` |
+| Demo source | `demos/11-shared-world/main.cpp` |
+| Player marker rendering | `demos/11-shared-world/main.cpp` (lines 914-919) |
+| Edit system | [Tutorial 08](08-camera-raycasting-interaction.md) |
+| HUD integration | [Tutorial 09](09-player-mechanics.md) |
+| Architecture overview | [`docs/architecture.md`](../architecture.md) |

--- a/docs/tutorials/12-simulation-fields.md
+++ b/docs/tutorials/12-simulation-fields.md
@@ -1,0 +1,333 @@
+# Tutorial 12: Simulation Fields
+
+Add fluid flow, heat propagation, and dynamic lighting to your world using
+sparse cellular automata that overlay the voxel grid. Fields are not embedded
+in `Voxel` -- they live in separate simulation systems that read and write the
+world through events.
+
+---
+
+## Prerequisites
+
+- Engine built and running ([Tutorial 01](01-hello-voxel.md))
+- Comfortable writing a plugin ([Tutorial 02](02-your-first-plugin.md))
+- Familiar with materials and properties ([Tutorial 03](03-materials-and-properties.md))
+- Understanding of the world and layer model (layers, chunks, edits via
+  `apply_edit`)
+
+---
+
+## 1. The field overlay model
+
+Simulation fields are **sparse cellular automata layered on top of the voxel
+grid**. Each field system (thermal, fluid, lighting) maintains its own sparse
+data structure keyed by world-space voxel coordinates. Cells are only allocated
+where the field is non-zero, so a lava lake does not cost memory in the frozen
+tundra on the far side of the map.
+
+The key design principle: fields are overlays, not data packed into the `Voxel`
+struct. A voxel's `MaterialProperties` (porosity, thermal conductivity, light
+emission) influence how fields propagate through it, but the field values
+themselves -- temperature, fluid amount, brightness -- live in the simulation
+systems.
+
+Each system follows the same lifecycle:
+
+1. Create the system, passing the `World` and `PluginManager`.
+2. Attach it to the engine via the corresponding setter.
+3. Register sources and event callbacks from your plugin.
+4. Tick the system each frame.
+
+```cpp
+auto thermal  = std::make_unique<sim::ThermalSystem>(world, pluginManager);
+auto fluid    = std::make_unique<sim::FluidSystem>(world, pluginManager);
+auto lighting = std::make_unique<sim::LightingSystem>(world, pluginManager);
+
+engine.setThermalSystem(thermal.get());
+engine.setFluidSystem(fluid.get());
+engine.setLightingSystem(lighting.get());
+
+// Per-frame tick (thermal before fluid):
+thermal->tick(dt);
+fluid->tick(dt);
+```
+
+The tick order matters: thermal runs first so that heat-dependent fluid
+behavior (e.g., ice melting) sees up-to-date temperatures. The lighting system
+is ticked internally by the renderer and does not require an explicit call.
+
+---
+
+## 2. Fluid system
+
+The fluid system simulates liquid flow through the voxel grid. Fluid spreads
+outward and downward from source cells, permeating through porous materials and
+pooling against impermeable walls.
+
+### Registering a fluid source
+
+A source continuously injects fluid at a given rate:
+
+```cpp
+ctx->register_fluid_source(ctx, WorldCoord(10, 5, 10), /*rate=*/0.5f, "water");
+```
+
+The `rate` is fluid units per second. The `material_id` string (`"water"`)
+determines the palette index used when the event fires.
+
+### Responding to fluid events
+
+When a cell crosses the saturation threshold (fills up) or drains below it, the
+system fires a `FluidEvent`. Your plugin decides what to do -- typically placing
+or removing a fluid material:
+
+```cpp
+ctx->register_on_fluid_event(ctx, [](const FluidEvent* event, void* ud) {
+    if (event->crossing == FieldCrossing::Rising) {
+        // Voxel saturated — place fluid material
+        Voxel fluid;
+        fluid.material.palette_index = event->palette_index;
+        ctx->apply_edit(ctx, event->position, &fluid);
+    } else {  // FieldCrossing::Falling
+        // Voxel drained — remove fluid
+        Voxel empty = Voxel::empty();
+        ctx->apply_edit(ctx, event->position, &empty);
+    }
+}, nullptr);
+```
+
+### FluidEvent struct
+
+```cpp
+struct FluidEvent {
+    WorldCoord position;
+    int64_t voxel_x, voxel_y, voxel_z;
+    float amount;
+    FieldCrossing crossing;  // Rising or Falling
+    const char* material_id;
+    uint8_t palette_index;
+};
+```
+
+`FieldCrossing::Rising` means the cell just reached saturation.
+`FieldCrossing::Falling` means the cell just drained below the threshold.
+
+### Porosity-driven permeation
+
+The `porosity` field in `MaterialProperties` controls how fluid moves through a
+material. High porosity (close to 1.0) lets fluid seep through freely -- think
+sand or gravel. Low porosity (close to 0.0) blocks flow -- think granite or
+glass. A porosity of exactly 0.0 makes the material fully impermeable; fluid
+pools against it.
+
+This means terrain composition directly shapes fluid behavior without any
+special-case code. Build a wall of stone and water stops. Build a sand dam and
+it slowly leaks through.
+
+---
+
+## 3. Thermal system
+
+The thermal system simulates heat diffusion through the voxel grid. Heat
+spreads from sources through surrounding voxels at a rate governed by each
+material's thermal conductivity.
+
+### Registering a heat source
+
+```cpp
+ctx->register_heat_source(ctx, WorldCoord(5, 3, 5), /*rate=*/100.0f);
+```
+
+The `rate` is temperature units per second emitted by the source.
+
+### Responding to thermal events
+
+When a cell's temperature crosses a threshold, the system fires a
+`ThermalFieldEvent`:
+
+```cpp
+ctx->register_on_thermal_event(ctx, [](const ThermalFieldEvent* event, void* ud) {
+    if (event->crossing == FieldCrossing::Rising) {
+        // Temperature threshold crossed — voxel is hot
+    }
+}, nullptr);
+```
+
+### ThermalFieldEvent struct
+
+```cpp
+struct ThermalFieldEvent {
+    WorldCoord position;
+    int64_t voxel_x, voxel_y, voxel_z;
+    float temperature;
+    FieldCrossing crossing;
+};
+```
+
+### Conductivity-driven diffusion
+
+Heat spreads faster through materials with high `thermal_conductivity`. Metal
+conducts heat quickly; wood conducts slowly; air barely at all. The diffusion
+solver uses a stability factor of `1/6` (see
+[`docs/configuration-guide.md`](../configuration-guide.md) for all tuning
+constants) to keep the simulation stable at any frame rate.
+
+---
+
+## 4. Lighting system
+
+The lighting system handles both sky light and block-emitter light. It
+propagates brightness through the voxel grid, attenuating per step, and
+computes ambient occlusion at mesh vertices.
+
+### Registering a point light
+
+```cpp
+ctx->register_light_source(ctx, WorldCoord(8, 6, 8), /*brightness=*/0.9f);
+```
+
+### Light emission via material
+
+Instead of placing explicit light sources, you can make a material glow by
+setting `light_emission` in its `MaterialProperties` (range 0.0 to 1.0). Every
+voxel of that material acts as a light source at the given brightness. This is
+the natural way to make lava, glowstone, or lantern blocks illuminate their
+surroundings.
+
+### Responding to lighting events
+
+```cpp
+ctx->register_on_lighting_event(ctx, [](const LightingEvent* event, void* ud) {
+    // event->brightness, event->crossing
+}, nullptr);
+```
+
+### LightingEvent struct
+
+```cpp
+struct LightingEvent {
+    WorldCoord position;
+    int64_t voxel_x, voxel_y, voxel_z;
+    float brightness;
+    FieldCrossing crossing;
+};
+```
+
+### Ambient occlusion
+
+The mesh builder bakes per-vertex ambient occlusion into the mesh. Each vertex
+samples its four neighboring voxel corners and applies a darkening factor:
+
+```cpp
+// tuning::ao::kVertexFactor[4] = {0.46, 0.64, 0.82, 1.0}
+```
+
+The four values correspond to 0, 1, 2, or 3 open (non-occluding) neighbors.
+Corners tucked into concavities get the darkest factor (0.46); fully exposed
+corners get 1.0 (no darkening). To disable AO entirely, set all four values to
+1.0.
+
+---
+
+## 5. Field readback
+
+You can query the current field value at any world position without waiting for
+an event:
+
+```cpp
+float temperature = engine.temperatureAt(position);
+float fluidAmount = engine.fluidAmountAt(position);
+float light       = engine.lightAt(position);
+```
+
+This is useful for HUD displays (show the temperature under the crosshair),
+gameplay logic (damage the player if temperature exceeds a threshold), or debug
+overlays.
+
+---
+
+## 6. Per-frame budgets via EngineConfig
+
+Each field system processes a bounded number of cells per frame to keep the
+simulation from stalling the render loop. The budget is configurable at runtime
+through `EngineConfig`:
+
+```cpp
+#include "core/EngineConfig.h"
+
+engineConfig().thermalMaxCellsPerFrame   = 8192;   // default 4096
+engineConfig().fluidMaxCellsPerFrame     = 8192;
+engineConfig().fluidMaxEventsPerFrame    = 512;    // default 256
+engineConfig().lightingMaxCellsPerFrame  = 16384;  // default 8192
+engineConfig().lightingMaxEventsPerFrame = 512;
+```
+
+When a tick exceeds its budget, the remaining work carries over to the next
+frame. Work is never lost, just deferred. This means a sudden flood of activity
+(breaking a dam, igniting a forest) spreads the cost over multiple frames rather
+than causing a single-frame hitch.
+
+For a complete guide to budget tuning across all engine systems, see
+[Tutorial 14: Performance Tuning](14-performance-tuning.md).
+
+---
+
+## 7. Translucent palette for fluid rendering
+
+Fluid materials like water and glass look best with translucent palette colors.
+Set the alpha channel below `0xff` to enable translucency:
+
+```cpp
+ctx->set_palette_color(ctx, 10, 0x50f0e8d8);  // alpha 0x50 = translucent
+```
+
+The renderer sorts translucent faces back-to-front automatically. See
+[Tutorial 03](03-materials-and-properties.md) for more on palette colors.
+
+---
+
+## How to verify
+
+1. **Build and run the flow-and-heat demo:**
+
+   ```bash
+   cmake -B build && cmake --build build
+   ./build/14-flow-and-heat
+   ```
+
+   You should see fluid spreading outward from source points, pooling against
+   impermeable walls, and seeping through porous materials. Heat sources glow
+   and warm nearby voxels. Walk near a heat source and observe the thermal
+   event threshold being crossed.
+
+2. **Build and run the HUD demo for field readback:**
+
+   ```bash
+   ./build/18-hud-and-controls
+   ```
+
+   The HUD displays live temperature, fluid amount, and light level under the
+   crosshair. Walk toward a fluid source or heat source and watch the values
+   change in real time.
+
+3. **Experiment with budgets:** Lower `fluidMaxCellsPerFrame` to 512 and
+   observe that fluid still spreads to the same extent -- it just takes more
+   frames to converge. Raise it back to 8192 and watch the simulation snap to
+   equilibrium faster.
+
+---
+
+## Key references
+
+| What | Where |
+|------|-------|
+| FluidEvent, ThermalFieldEvent, LightingEvent structs | [`include/plugin_api.h`](../../include/plugin_api.h) |
+| FieldCrossing enum | [`include/plugin_api.h`](../../include/plugin_api.h) |
+| MaterialProperties (porosity, thermal_conductivity, light_emission) | [`include/plugin_api.h`](../../include/plugin_api.h) |
+| EngineConfig (per-frame budgets) | [`include/core/EngineConfig.h`](../../include/core/EngineConfig.h) |
+| Tuning constants (AO, thermal, fluid, lighting) | `include/core/Tuning.h` |
+| Flow-and-heat demo | `demos/14-flow-and-heat/main.cpp` |
+| HUD demo (field readback) | `demos/18-hud-and-controls/main.cpp` |
+| Architecture: simulation fields | [`docs/architecture.md`](../architecture.md) |
+| Configuration guide | [`docs/configuration-guide.md`](../configuration-guide.md) |
+| Performance tuning | [Tutorial 14](14-performance-tuning.md) |

--- a/docs/tutorials/13-structural-collapse.md
+++ b/docs/tutorials/13-structural-collapse.md
@@ -1,0 +1,321 @@
+# Tutorial 13: Structural Collapse
+
+Configure structural physics so that unsupported voxels collapse, and write
+custom plugins that decide how the collapse looks -- crumbling in place,
+falling debris, or scale-filtered cascades through a multi-level composite
+hierarchy.
+
+---
+
+## Prerequisites
+
+- Engine built and running ([Tutorial 01](01-hello-voxel.md))
+- Comfortable writing a plugin ([Tutorial 02](02-your-first-plugin.md))
+- Familiar with materials and `structural_strength` ([Tutorial 03](03-materials-and-properties.md))
+- Understanding of composite vs. terminal layers and the decomposition model
+
+---
+
+## 1. The propagation system
+
+The engine's `PropagationSystem` monitors the structural integrity of every
+composite macro in the world. When a terminal voxel is removed or modified, the
+system walks upward through the composite hierarchy, re-aggregates strength,
+and runs a support-flood to determine whether each ancestor is still stable.
+
+The key insight: **the engine detects instability but does not decide the
+response.** Detection is built in; response is delegated to plugins via the
+`on_structural_event` callback. This separation lets you swap between a simple
+crumble effect, a physics-driven debris shower, or complete structural
+immunity -- all without modifying engine code.
+
+### PhysicsSystem setup
+
+```cpp
+auto physics = std::make_unique<sim::PhysicsSystem>(world, pluginManager);
+// Ticked each frame:
+physics->tick();
+```
+
+The `PhysicsSystem` wraps `PropagationSystem` and exposes it through the plugin
+API.
+
+---
+
+## 2. How upward propagation works
+
+When you break a block, here is what happens inside the engine:
+
+1. **Terminal voxel removed** -- an edit via `apply_edit` clears a leaf voxel.
+2. **`on_voxel_modified` fires** -- the `PropagationSystem` hooks this event
+   internally via `PropagationSystem::onVoxelModified()`.
+3. **Aggregate re-computation** -- the parent composite's `aggregate_strength`
+   and density are recalculated as a volume-weighted average of its children.
+4. **Support-flood** -- starting from anchors (immutable voxels and
+   non-resident chunk boundaries), potential `1.0` floods outward. Potential
+   drains by `1 / maxSpan(strength)` per hop, where `maxSpan` is
+   `strength * kSupportSpanPerStrength` capped at `kMaxSupportSpan`.
+5. **Instability detected** -- any macro with `support_potential <= 0` is
+   unstable. The engine fires `on_structural_event`.
+6. **Plugin responds** -- the callback clears, relocates, or ignores the
+   unstable voxels.
+7. **Cascade** -- if the response clears children, those edits fire further
+   `on_voxel_modified` events, which propagate upward to grandparents, and so
+   on.
+
+This upward cascade is what makes multi-level collapse work: mining out a 1 m
+terminal voxel can topple a 4 m macro three levels above it.
+
+---
+
+## 3. The StructuralEvent struct
+
+Every instability notification arrives as a `StructuralEvent`:
+
+```cpp
+struct StructuralEvent {
+    WorldCoord position;           // world-space center of unstable macro
+    int64_t voxel_x, voxel_y, voxel_z;  // macro VoxelCoord
+    const char* layer_name;        // composite layer the macro belongs to
+    double voxel_size_m;           // edge length of macro
+    float aggregate_strength;      // post-edit volume-weighted structural_strength
+    float support_potential;       // <= 0 means unstable
+    double child_voxel_size_m;     // edge length of terminal children
+};
+```
+
+| Field | Meaning |
+|-------|---------|
+| `position` | World-space center of the unstable macro voxel. |
+| `layer_name` | Which composite layer this macro belongs to. |
+| `voxel_size_m` | Edge length of the macro. A 4 m macro contains 8x8x8 children of 0.5 m each. |
+| `aggregate_strength` | Volume-weighted average of children's `structural_strength`. Higher means stronger. |
+| `support_potential` | Result of the support-flood. Positive = supported. Zero or negative = unsupported -- collapse. |
+| `child_voxel_size_m` | Edge length of the terminal (leaf) children. Useful for iterating over them in the response. |
+
+---
+
+## 4. Registering a structural event handler
+
+A minimal collapse response that clears every terminal child of the unstable
+macro:
+
+```cpp
+ctx->register_on_structural_event(ctx, [](const StructuralEvent* event, void* ud) {
+    // event->support_potential <= 0 means unstable
+    // Response: clear the macro's children
+    double childSize = event->child_voxel_size_m;
+    int ratio = static_cast<int>(event->voxel_size_m / childSize);
+    Voxel empty = Voxel::empty();
+    for (int z = 0; z < ratio; ++z)
+        for (int y = 0; y < ratio; ++y)
+            for (int x = 0; x < ratio; ++x) {
+                WorldCoord childPos(
+                    event->position.value.x - event->voxel_size_m * 0.5 + (x + 0.5) * childSize,
+                    event->position.value.y - event->voxel_size_m * 0.5 + (y + 0.5) * childSize,
+                    event->position.value.z - event->voxel_size_m * 0.5 + (z + 0.5) * childSize);
+                ctx->apply_edit(ctx, childPos, &empty);
+            }
+}, nullptr);
+```
+
+The nested loops walk every terminal child position inside the macro's bounding
+cube and clear it. Each `apply_edit` may trigger further structural events
+upward -- this is the cascade mechanism.
+
+---
+
+## 5. Immutable boundaries
+
+Propagation stops at immutable layers. Immutable voxels (typically bedrock or
+world-border layers) serve as permanent anchors for the support flood. They
+emit a support potential of `1.0` and never become unstable themselves.
+
+This means:
+
+- A column of voxels resting on bedrock is fully supported.
+- A floating island with no connection to any immutable layer will collapse as
+  soon as you break one block (assuming the support-flood cannot reach an
+  anchor within `kMaxSupportSpan` hops).
+- Non-resident chunk boundaries also act as implicit anchors, preventing
+  collapse at the edge of the loaded world.
+
+---
+
+## 6. Reference response plugins
+
+The engine ships two response plugins that demonstrate different collapse
+styles:
+
+### crumble
+
+Located at `plugins/crumble/plugin.cpp`. Clears all terminal children of the
+unstable macro via `apply_edit`, producing a "the block vanishes" effect.
+Simple and fast.
+
+### falling-debris
+
+Located at `plugins/falling-debris/plugin.cpp`. Relocates material downward in
+a gravity-aware fashion. Voxels "fall" from the unstable macro and stack on the
+surface below. More visually interesting but heavier on edits.
+
+Both plugins can be hot-swapped at runtime:
+
+```cpp
+if (responsePlugin != kInvalidPluginId)
+    pluginManager.unloadPlugin(responsePlugin);
+responsePlugin = pluginManager.loadPlugin(crumblePath);
+```
+
+This lets you switch collapse behavior without restarting the engine -- useful
+for gameplay modes or debug toggling.
+
+---
+
+## 7. Multi-level collapse cascades
+
+Demo 19 (`19-multilevel-collapse`) demonstrates a deep composite stack:
+
+```
+macro (4 m) -> micro (2 m) -> grid (1 m terminal) + bedrock (0.5 m immutable)
+```
+
+Mining a 1 m grid voxel can propagate instability upward through micro and
+macro layers. The cascade works because each cleared child triggers
+`on_voxel_modified` on its parent, which re-aggregates and re-floods.
+
+### Scale-filtered response
+
+In a multi-level world you often want different responses at different scales.
+For example, only collapse at the coarsest (grandparent) scale and let
+intermediate levels absorb small edits:
+
+```cpp
+void grandparentCrumble(const StructuralEvent* ev, void* ud) {
+    if (std::llround(ev->voxel_size_m) != 4) return;  // only 4 m macros
+    // Clear all grid grandchildren...
+}
+```
+
+By filtering on `voxel_size_m`, the same callback ignores instability events
+at the 2 m micro scale and only fires the dramatic collapse when the 4 m macro
+itself becomes unstable.
+
+---
+
+## 8. In-process plugin registration
+
+For demos and tests that do not use shared-library plugins, you can register a
+structural event handler using the `wireInPlugin` pattern:
+
+```cpp
+int myCollapseInit(PluginContext* ctx) {
+    ctx->register_on_structural_event(ctx, myHandler, nullptr);
+    return 0;
+}
+pluginManager.wireInPlugin(myCollapseInit);
+```
+
+This wires the handler directly into the plugin manager without loading a
+`.so`/`.dll`. See [Tutorial 02](02-your-first-plugin.md) for the full plugin
+lifecycle.
+
+---
+
+## 9. PropagationSystem internals
+
+For advanced use (diagnostics, custom editors), the `PropagationSystem` exposes
+several query functions:
+
+| Function | Purpose |
+|----------|---------|
+| `active()` | Returns `true` when at least one composite-to-child level exists. |
+| `levelCount()` | Number of composite levels in the hierarchy. |
+| `recomputeAggregate(level, macroVoxelCoord)` | Force a full O(ratio^3) re-summation of a macro's children. |
+| `aggregateStrength(level, macroVoxelCoord)` | Read the current volume-weighted average strength. |
+
+These are engine internals, not part of the plugin API. Use them from demo code
+or engine-level tooling.
+
+---
+
+## 10. Tuning constants
+
+Structural physics behavior is governed by constants in `Tuning.h` and runtime
+budgets in `EngineConfig`:
+
+### Tuning.h (compile-time)
+
+| Constant | Default | Purpose |
+|----------|---------|---------|
+| `tuning::physics::kSupportSpanPerStrength` | 5.0 | Voxels of support reach per unit of `structural_strength`. A material with strength 2.0 supports up to 10 voxels horizontally. |
+| `tuning::physics::kMaxSupportSpan` | 16 | Absolute cap on support reach regardless of strength. |
+
+### EngineConfig (runtime)
+
+| Knob | Default | Purpose |
+|------|---------|---------|
+| `physicsMaxStructuralEventsPerFrame` | 256 | Cap on structural events fired per frame. |
+| `physicsMaxSupportFloodNodes` | 4096 | Cap on nodes visited during support-flood per frame. |
+| `physicsMaxAggregateRecomputesPerFrame` | 64 | Cap on aggregate re-summations per frame. |
+
+Overflow carries to the next frame -- work is deferred, never lost. For a
+complete guide to budget tuning, see
+[Tutorial 14: Performance Tuning](14-performance-tuning.md).
+
+The `structural_strength` field in `MaterialProperties` is the key material
+property for structural behavior. Higher values mean a wider support span and
+more stable structures. See
+[Tutorial 03](03-materials-and-properties.md) for how to define materials with
+different strength values.
+
+---
+
+## How to verify
+
+1. **Build and run the structural-collapse demo:**
+
+   ```bash
+   cmake -B build && cmake --build build
+   ./build/13-structural-collapse
+   ```
+
+   Mine out blocks from a supported structure. When enough material is removed,
+   the unsupported portion collapses. Try building a horizontal overhang and
+   extending it until it exceeds the support span -- it should collapse when
+   the reach limit is crossed.
+
+2. **Build and run the multi-level collapse demo:**
+
+   ```bash
+   ./build/19-multilevel-collapse
+   ```
+
+   This demo uses a deep composite hierarchy. Mine terminal voxels at the
+   base and watch the collapse cascade upward through multiple composite
+   levels. Note that the response only fires at the coarsest scale (4 m
+   macros) -- intermediate levels absorb small edits without collapsing.
+
+3. **Swap response plugins at runtime:** In either demo, use the plugin
+   hot-swap mechanism to switch between `crumble` and `falling-debris` and
+   observe the different collapse styles.
+
+---
+
+## Key references
+
+| What | Where |
+|------|-------|
+| StructuralEvent struct | [`include/plugin_api.h`](../../include/plugin_api.h) |
+| MaterialProperties (structural_strength) | [`include/plugin_api.h`](../../include/plugin_api.h) |
+| PropagationSystem | `src/sim/PropagationSystem.h` |
+| PhysicsSystem | `src/sim/PhysicsSystem.h` |
+| crumble plugin | `plugins/crumble/plugin.cpp` |
+| falling-debris plugin | `plugins/falling-debris/plugin.cpp` |
+| Structural-collapse demo | `demos/13-structural-collapse/main.cpp` |
+| Multi-level collapse demo | `demos/19-multilevel-collapse/main.cpp` |
+| Tuning constants (support span, max span) | `include/core/Tuning.h` |
+| EngineConfig (physics budgets) | [`include/core/EngineConfig.h`](../../include/core/EngineConfig.h) |
+| Architecture: structural propagation | [`docs/architecture.md`](../architecture.md) |
+| Materials tutorial | [Tutorial 03](03-materials-and-properties.md) |
+| Performance tuning | [Tutorial 14](14-performance-tuning.md) |

--- a/docs/tutorials/14-performance-tuning.md
+++ b/docs/tutorials/14-performance-tuning.md
@@ -1,0 +1,384 @@
+# Tutorial 14: Performance Tuning
+
+Profile and tune your game using three configuration surfaces: YAML layer
+configs for world shape, compile-time constants in `Tuning.h` for model
+parameters, and runtime `EngineConfig` knobs for per-frame work budgets.
+Combine these with fog, far-clip, and streaming controls to ship a smooth
+experience on a range of hardware.
+
+---
+
+## Prerequisites
+
+- Engine built and running ([Tutorial 01](01-hello-voxel.md))
+- A working game or demo with at least one composite layer
+- Familiarity with simulation fields ([Tutorial 12](12-simulation-fields.md))
+  and structural physics ([Tutorial 13](13-structural-collapse.md)) if you use
+  those systems
+
+---
+
+## 1. Three configuration surfaces
+
+The engine separates configuration into three layers, each with a different
+scope and edit cycle:
+
+| Surface | When to change | Rebuild needed? |
+|---------|---------------|-----------------|
+| **YAML (LayerConfig)** | Per project -- world shape, layer stack, streaming radii | No (loaded at startup) |
+| **Tuning.h** | Rarely -- model constants that define simulation behavior | Yes (compile-time constexpr) |
+| **EngineConfig** | Frequently -- per-frame budgets, quality presets, live tuning | No (runtime, immediate effect) |
+
+The general rule: start with EngineConfig for quick iteration, then lock in
+YAML for your world layout, and only touch Tuning.h when you need to change
+fundamental simulation behavior.
+
+---
+
+## 2. YAML (LayerConfig) -- world shape
+
+The layer config YAML defines the world's layer stack and is loaded once at
+startup. Changing it requires restarting the demo but not recompiling.
+
+```yaml
+layers:
+  - name: terrain
+    voxel_size_m: 1.0
+    mode: terminal
+    chunk_size_voxels: 32
+    view_distance_chunks: 8
+    resident_chunk_budget: 4096
+    streaming_volume:
+      shape: box
+```
+
+### Key performance knobs
+
+| Field | Effect |
+|-------|--------|
+| `chunk_size_voxels` | Larger chunks = fewer draw calls but coarser streaming granularity. 32 is a good default. |
+| `view_distance_chunks` | Load/evict radius. Halving this roughly quarters the resident chunk count. |
+| `resident_chunk_budget` | Hard cap on chunks loaded per layer. `0` = unlimited. Farthest-first eviction when over budget. |
+| `streaming_volume.shape` | `box` (default), `sphere` (excludes corners for ~21% fewer chunks), `shell` (thin ring for backdrop-only layers). |
+
+### Decoupling decomposition from view distance
+
+For composite layers, you can set `decompose_distance_m` separately from
+`view_distance_chunks`. This lets you show coarse silhouettes far out while
+only decomposing to fine detail up close:
+
+```yaml
+layers:
+  - name: blocks
+    voxel_size_m: 8.0
+    mode: composite
+    decompose_to: terrain
+    view_distance_chunks: 12    # show silhouettes far out
+    decompose_distance_m: 64.0  # only decompose within 64 m
+```
+
+Geometry beyond the decompose distance renders as solid macro blocks -- cheap
+to draw and visually acceptable when combined with fog (see section 7).
+
+For the complete YAML field catalog, see
+[`docs/configuration-guide.md`](../configuration-guide.md).
+
+---
+
+## 3. Tuning.h -- compile-time constants
+
+These `constexpr` values in `Tuning.h` define the simulation model. They
+require a rebuild to change, so treat them as project-level decisions rather
+than per-session tuning.
+
+| Namespace | Constant | Default | Purpose |
+|-----------|----------|---------|---------|
+| `tuning::physics` | `kSupportSpanPerStrength` | 5.0 | Voxels of support reach per unit of `structural_strength` |
+| `tuning::physics` | `kMaxSupportSpan` | 16 | Absolute cap on support reach |
+| `tuning::thermal` | `kAmbientTemperature` | 20.0 | Baseline temperature (degrees) |
+| `tuning::thermal` | `kStabilityFactor` | 1/6 | Diffusion stability bound |
+| `tuning::fluid` | `kSaturationThreshold` | 1.0 | Fluid amount that triggers a saturation event |
+| `tuning::lighting` | `kAmbientBrightness` | 0.05 | Baseline light level everywhere |
+| `tuning::lighting` | `kAttenuationPerStep` | 1/15 | Light falloff per voxel step |
+| `tuning::ao` | `kVertexFactor[4]` | {0.46, 0.64, 0.82, 1.0} | Per-vertex AO darkening factors |
+
+The AO factors deserve special attention: set all four to `1.0` to disable
+ambient occlusion entirely (useful for a flat-shaded art style or to save mesh
+vertex bandwidth).
+
+---
+
+## 4. EngineConfig -- runtime budgets
+
+`EngineConfig` is the primary tool for frame-to-frame performance control. All
+budgets take effect immediately -- no restart needed.
+
+```cpp
+#include "core/EngineConfig.h"
+
+// Decomposition throughput
+engineConfig().decompositionLoadPerFrame   = 8;    // default 4
+engineConfig().decompositionDecompPerFrame = 128;  // default 64
+engineConfig().decompositionApplyPerFrame  = 32;   // default 16
+
+// Streaming residency
+engineConfig().streamingHysteresisChunks = 3;      // default 2
+
+// Structural propagation
+engineConfig().physicsMaxAggregateRecomputesPerFrame = 128;
+engineConfig().physicsMaxStructuralEventsPerFrame    = 512;
+engineConfig().physicsMaxSupportFloodNodes           = 8192;
+
+// Simulation fields
+engineConfig().thermalMaxCellsPerFrame   = 8192;
+engineConfig().fluidMaxCellsPerFrame     = 8192;
+engineConfig().fluidMaxEventsPerFrame    = 512;
+engineConfig().lightingMaxCellsPerFrame  = 16384;
+engineConfig().lightingMaxEventsPerFrame = 512;
+
+// Reset everything to defaults:
+resetEngineConfig();
+```
+
+### Overflow semantics
+
+When a system exceeds its per-frame budget, the remaining work carries over to
+the next frame. Work is deferred, never lost. This means a sudden spike (a dam
+breaking, a building collapsing) spreads its cost over multiple frames rather
+than causing a single-frame hitch.
+
+### Quality presets
+
+A common pattern is to define named quality levels that set all budgets at
+once:
+
+```cpp
+void setQualityLow() {
+    engineConfig().decompositionLoadPerFrame = 2;
+    engineConfig().thermalMaxCellsPerFrame   = 2048;
+    engineConfig().fluidMaxCellsPerFrame     = 2048;
+}
+
+void setQualityHigh() {
+    engineConfig().decompositionLoadPerFrame = 8;
+    engineConfig().thermalMaxCellsPerFrame   = 8192;
+    engineConfig().fluidMaxCellsPerFrame     = 8192;
+}
+```
+
+This keeps the quality menu simple for players while giving you fine-grained
+control over every subsystem.
+
+### Streaming hysteresis
+
+`streamingHysteresisChunks` prevents load/evict thrashing at the view-distance
+boundary. With the default value of 2, a chunk is loaded when the player enters
+`view_distance_chunks` but not evicted until the player moves
+`view_distance_chunks + 2` chunks away. Increase this if you see chunks
+flickering in and out at the edge of the view.
+
+---
+
+## 5. EngineMetrics
+
+Query the engine's internal counters to identify bottlenecks:
+
+```cpp
+EngineMetrics metrics = engine.getMetrics();
+// Contains: frame time, draw calls, resident chunks per layer,
+// decomposition queue depth, voice count, etc.
+```
+
+Use `EngineMetrics` to build in-game performance overlays, log per-frame stats
+to a file, or drive adaptive quality -- automatically lowering budgets when
+frame time exceeds a target.
+
+---
+
+## 6. Logging
+
+The engine's logging system helps diagnose performance problems without
+attaching a debugger:
+
+```cpp
+#include "core/Logger.h"
+
+Log::setMinLevel(Log::Level::Info);  // Debug, Info, Warn, Error
+Log::info("MyGame", "Player spawned at origin");
+Log::warn("MyGame", "Chunk budget exceeded");
+Log::error("MyGame", "Failed to load plugin");
+```
+
+### Category-tagged logging
+
+Use category tags to filter log output by subsystem:
+
+```cpp
+static constexpr const char* kLogCat = "terrain";
+Log::debug(kLogCat, "Generating chunk at (0,0,0)");
+```
+
+### Custom log handler
+
+Route log output to a file, network endpoint, or in-game console:
+
+```cpp
+Log::setHandler([](Log::Level lvl, const char* cat, const char* msg) {
+    // Write to file, send to network, etc.
+});
+Log::setHandler(nullptr);  // restore stderr default
+```
+
+Set the minimum level to `Debug` during development to see budget overflow
+warnings from the simulation systems, then raise it to `Info` or `Warn` for
+release.
+
+---
+
+## 7. Fog and far-clip as LOD-hiding tools
+
+Fog and far-clip are not just visual effects -- they are performance tools.
+Use them to hide the LOD transition where fully decomposed terrain meets coarse
+macro silhouettes.
+
+### Fog
+
+```cpp
+#include "renderer/Fog.h"
+
+FogParams fog{};
+fog.color   = glm::vec3(0.6f, 0.65f, 0.7f);  // sky-like blue-gray
+fog.near_m  = 80.0f;   // fog starts
+fog.far_m   = 200.0f;  // fog at full strength
+fog.density = 0.8f;    // max strength [0,1]; 0 = no fog
+
+renderer.setFog(fog);
+```
+
+The default density of `0` means no fog at all -- byte-identical behavior to
+pre-fog engine builds. Set `density > 0` to enable it.
+
+### Match fog color to clear color
+
+For geometry to dissolve seamlessly into the background, match the fog color
+to the renderer's clear color:
+
+```cpp
+renderer.setClearColor(glm::vec3(0.6f, 0.65f, 0.7f));
+```
+
+### Placement strategy
+
+Tune the fog `near_m` distance to sit just inside the `decompose_distance_m`
+so that the transition from detailed terrain to coarse silhouettes happens
+inside the fog band and is invisible to the player.
+
+### Far clip
+
+```cpp
+renderer.setFarClip(500.0f);  // meters
+```
+
+Set the far clip beyond the fog's `far_m` so that geometry is fully fogged out
+before it gets clipped. If far-clip is closer than the fog far distance, you
+will see hard edges where geometry pops out of existence.
+
+---
+
+## 8. Streaming tuning
+
+Fine-tune how the engine loads and evicts chunks around the player:
+
+### Per-layer YAML knobs
+
+| Knob | Purpose |
+|------|---------|
+| `view_distance_chunks` | Load/evict radius in chunks. |
+| `resident_chunk_budget` | Hard cap on resident chunks per layer. `0` = unlimited. Farthest-first eviction when over budget. |
+| `decompose_distance_m` | Decouple decomposition from view distance. Show coarse silhouettes far out, decompose to fine grid only up close. |
+| `streaming_volume.shape` | `box` (default), `sphere` (excludes corners), `shell` (thin ring for backdrop-only layers). |
+
+### Hysteresis
+
+`engineConfig().streamingHysteresisChunks` (default 2) adds a buffer zone
+between the load and evict boundaries. Without hysteresis, a player standing
+exactly at the view-distance edge would cause chunks to thrash in and out every
+frame.
+
+### Resident chunk budget
+
+When the number of loaded chunks exceeds `resident_chunk_budget`, the engine
+evicts the farthest chunks first. This gives you a hard memory ceiling per
+layer. Set it based on your target platform's available memory.
+
+---
+
+## 9. Putting it all together
+
+A typical tuning workflow:
+
+1. **Measure** -- enable `Log::Level::Debug`, run your game, and collect
+   `EngineMetrics` each frame. Identify which system is blowing its budget.
+2. **Adjust budgets** -- raise the bottleneck system's EngineConfig budget or
+   lower competing systems. Verify frame time improves.
+3. **Tune streaming** -- reduce `view_distance_chunks` or add a
+   `resident_chunk_budget` if memory is the constraint.
+4. **Add fog** -- hide the LOD seam with fog. Match the fog band to your
+   `decompose_distance_m`.
+5. **Lock in YAML** -- once you have found good streaming parameters, commit
+   them to your layer config YAML.
+6. **Profile deeply** -- for detailed frame-level profiling data, see
+   [`docs/m17-performance-profiling.md`](../m17-performance-profiling.md).
+
+---
+
+## How to verify
+
+1. **Budget overflow test:** Run any demo with simulation fields (e.g.,
+   `14-flow-and-heat`). Set `fluidMaxCellsPerFrame` to 64 and observe the
+   fluid spreading slowly over many frames. Set it to 16384 and watch it
+   converge almost instantly. The final result is identical -- only the
+   convergence speed changes.
+
+   ```bash
+   cmake -B build && cmake --build build
+   ./build/14-flow-and-heat
+   ```
+
+2. **Fog tuning:** Run `05-decompose-on-approach` and enable fog. Fly outward
+   and verify that macro silhouettes dissolve into fog before you notice the
+   LOD transition.
+
+   ```bash
+   ./build/05-decompose-on-approach
+   ```
+
+3. **Streaming residency:** In any multi-layer demo, set
+   `resident_chunk_budget` to a low value (e.g., 64) in the YAML and observe
+   farthest-first eviction as you move through the world. Chunks behind you
+   evict to stay within budget.
+
+4. **Quality presets:** Implement the `setQualityLow` / `setQualityHigh`
+   pattern from section 4 in your game and toggle between them at runtime.
+   Watch `EngineMetrics` frame time change accordingly.
+
+5. **Logging:** Set `Log::setMinLevel(Log::Level::Debug)` and look for budget
+   overflow messages in stderr during heavy simulation activity.
+
+---
+
+## Key references
+
+| What | Where |
+|------|-------|
+| EngineConfig (all runtime knobs) | [`include/core/EngineConfig.h`](../../include/core/EngineConfig.h) |
+| Tuning constants (all compile-time) | `include/core/Tuning.h` |
+| LayerConfig (YAML schema) | [`include/core/LayerConfig.h`](../../include/core/LayerConfig.h) |
+| EngineMetrics | `include/core/EngineMetrics.h` |
+| Logger | [`include/core/Logger.h`](../../include/core/Logger.h) |
+| FogParams | [`include/renderer/Fog.h`](../../include/renderer/Fog.h) |
+| Configuration guide (full knob catalog) | [`docs/configuration-guide.md`](../configuration-guide.md) |
+| Performance profiling data | [`docs/m17-performance-profiling.md`](../m17-performance-profiling.md) |
+| Simulation fields (field budgets) | [Tutorial 12](12-simulation-fields.md) |
+| Structural collapse (physics budgets) | [Tutorial 13](13-structural-collapse.md) |
+| Materials (structural_strength, porosity, conductivity) | [Tutorial 03](03-materials-and-properties.md) |


### PR DESCRIPTION
Progressive tutorial series under docs/tutorials/, from first build
to performance tuning. Each tutorial is self-contained with real API
snippets, prerequisites, a "How to verify" section pointing to a
specific demo, and a key-references table. Covers: engine setup,
plugins, materials, composition recipes, multi-face blocks, asset
import/export (MagicaVoxel/Qubicle/Blockbench), multi-layer worlds,
camera/raycasting/interaction, player mechanics with HUD, audio,
multiplayer, simulation fields, structural collapse, and performance
tuning. Written against the plan in docs/m18-tutorial-series-plan.md.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Msgz5P2PD7mUC36ed9dH3a